### PR TITLE
feat(frontend): исполнение кода через runner API

### DIFF
--- a/src/pages/blocks/BlocksPage.js
+++ b/src/pages/blocks/BlocksPage.js
@@ -1,69 +1,37 @@
-/**
- * @module pages/blocks/BlocksPage
- *
- * Страница редактора ноутбука (/notebooks/:id).
- * Загружает данные ноутбука и пользователя, рендерит header, toolbar,
- * sidebar и список ячеек.
- */
-
 import { NotebookHeader } from '../../widgets/notebook-header/NotebookHeader.js';
 import { NotebookToolbar } from '../../widgets/notebook-toolbar/NotebookToolbar.js';
 import { NotebookSidebar } from '../../widgets/notebook-sidebar/NotebookSidebar.js';
 import { CellList } from '../../widgets/cell-list/CellList.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
+import { RunnerApi } from '../../shared/api/RunnerApi.js';
 import { Router } from '../../shared/router/Router.js';
 
-/** @typedef {import('../../shared/types.js').Notebook} Notebook */
-
-/**
- * Страница /notebooks/:id -- редактор ноутбука с code/text ячейками.
- * При отсутствии авторизации редиректит на /sign,
- * при ошибке загрузки ноутбука -- на /files.
- */
 export class BlocksPage {
-    /** @type {HTMLElement} */
     #root;
-
-    /** @type {string} */
     #notebookId;
-
-    /** @type {NotebookHeader} */
     #header;
-
-    /** @type {NotebookToolbar} */
     #toolbar;
-
-    /** @type {NotebookSidebar} */
     #sidebar;
-
-    /** @type {CellList} */
     #cellList;
-
-    /** @type {?Notebook} */
     #notebook = null;
-
-    /** @type {string} */
     #username = '';
     #avatarUrl = '';
     #httpClient;
+    #runnerApi;
 
-    /**
-     * @param {HTMLElement} root -- корневой элемент
-     * @param {Object} params -- параметры маршрута
-     * @param {string} params.id -- идентификатор ноутбука
-     */
+    // Сохранение execution state при re-renders (move, add, reload)
+    #executionCounter = 0;
+    #execNumbers = new Map(); // blockId -> execution number
+    #lastOutputs = new Map(); // blockId -> output object
+    #beforeUnloadHandler = null;
+
     constructor(root, params) {
         this.#root = root;
         this.#notebookId = params.id;
         this.#httpClient = HttpClient.getInstance();
+        this.#runnerApi = new RunnerApi();
     }
 
-    /**
-     * Загружает данные пользователя и ноутбука, затем строит layout.
-     *
-     * @async
-     * @returns {Promise<void>}
-     */
     async render() {
         this.#root.innerHTML = '';
 
@@ -97,11 +65,6 @@ export class BlocksPage {
         this.#buildLayout();
     }
 
-    /**
-     * Собирает DOM-структуру страницы: создаёт области для header, toolbar, sidebar и cell list, монтирует все виджеты и загружает блоки ноутбука.
-     *
-     * @private
-     */
     #buildLayout() {
         const page = document.createElement('div');
         page.className = 'blocks-page';
@@ -130,7 +93,7 @@ export class BlocksPage {
         this.#toolbar = new NotebookToolbar(headerArea, {
             onAddCode: () => this.#createBlock('code'),
             onAddText: () => this.#createBlock('text'),
-            onRunAll: () => {}
+            onRunAll: () => this.#runAllBlocks()
         });
         this.#toolbar.mount();
 
@@ -149,26 +112,30 @@ export class BlocksPage {
         main.className = 'blocks-page__main';
         body.appendChild(main);
 
-        this.#cellList = new CellList(main);
+        this.#cellList = new CellList(main, {
+            onRunCell: (blockId) => this.#runSingleBlock(blockId),
+            onRerender: () => this.#reapplyCellState()
+        });
         this.#cellList.mount();
 
         this.#root.appendChild(page);
 
         const blocks = this.#notebook.blocks || [];
         this.#cellList.updateBlocks(blocks);
+
+        // Остановка runner-сессии при закрытии вкладки / F5
+        this.#beforeUnloadHandler = () => {
+            if (this.#notebookId) this.#runnerApi.stopSessionBeacon(this.#notebookId);
+        };
+        window.addEventListener('beforeunload', this.#beforeUnloadHandler);
     }
 
-    /**
-     * Создаёт новый блок через API и перезагружает список ячеек.
-     *
-     * @private
-     * @async
-     * @param {string} type -- 'code' или 'text'
-     */
     async #createBlock(type) {
         try {
             const body = { type, content: '' };
             if (type === 'code') {
+                // TODO(runner-r): бэкенд сейчас хардкодит Python в runner_service.go:58.
+                // Когда это будет исправлено -- добавить language selector в toolbar.
                 body.language = 'python';
             }
             const response = await this.#httpClient.post(
@@ -181,6 +148,7 @@ export class BlocksPage {
             if (!reloadResponse.ok) return;
             const { data: notebook } = await reloadResponse.json();
             this.#notebook = notebook;
+            // updateBlocks автоматически зовёт onRerender → #reapplyCellState
             this.#cellList.updateBlocks(notebook.blocks || []);
         } catch (e) {
             console.error('Failed to create block:', e);
@@ -188,12 +156,112 @@ export class BlocksPage {
     }
 
     /**
-     * Переименовывает ноутбук через PUT /notebooks/:id.
-     *
-     * @private
-     * @async
-     * @param {string} newTitle -- новое название
+     * Исполнить один блок по id. Вызывается из CellList onRunCell.
+     * @param {number|string} blockId
      */
+    async #runSingleBlock(blockId) {
+        const cell = this.#cellList.getCellByBlockId(blockId);
+        if (!cell) return;
+        const position = this.#cellList.getBlockPositionById(blockId);
+        if (position < 0) return;
+
+        // Сохранить актуальное содержимое textarea на бэк перед исполнением,
+        // иначе runner выполнит старую версию из БД.
+        await this.#maybeSaveCellContent(blockId, cell);
+
+        cell.setRunning(true);
+        try {
+            const result = await this.#runnerApi.executeBlock(this.#notebookId, position);
+            this.#executionCounter += 1;
+            this.#execNumbers.set(blockId, this.#executionCounter);
+            this.#lastOutputs.set(blockId, {
+                stdout: result.stdout,
+                stderr: result.stderr,
+                result: result.result
+            });
+            cell.setExecutionNumber(this.#executionCounter);
+            cell.setOutput(this.#lastOutputs.get(blockId));
+        } catch (e) {
+            const errOut = { error: e.message || String(e) };
+            this.#lastOutputs.set(blockId, errOut);
+            cell.setOutput(errOut);
+        } finally {
+            cell.setRunning(false);
+        }
+    }
+
+    /**
+     * Исполнить все code-блоки с нулевой позиции.
+     */
+    async #runAllBlocks() {
+        const codeCells = this.#cellList.getCodeCellsInOrder();
+        if (codeCells.length === 0) return;
+
+        // Персист содержимого всех ячеек перед запуском
+        for (const c of codeCells) {
+            await this.#maybeSaveCellContent(c.getBlockId(), c);
+        }
+
+        codeCells.forEach((c) => {
+            c.setRunning(true);
+            c.clearOutput();
+        });
+
+        try {
+            const results = await this.#runnerApi.executeFromPosition(this.#notebookId, 0);
+            if (!Array.isArray(results)) return;
+            results.forEach((r) => {
+                const cell = this.#cellList.getCellByBlockId(r.block_id);
+                if (!cell || !cell.setOutput) return;
+                this.#executionCounter += 1;
+                this.#execNumbers.set(r.block_id, this.#executionCounter);
+                const out = { stdout: r.stdout, stderr: r.stderr, result: r.result };
+                this.#lastOutputs.set(r.block_id, out);
+                cell.setExecutionNumber(this.#executionCounter);
+                cell.setOutput(out);
+            });
+        } catch (e) {
+            const errOut = { error: `Run-all failed: ${e.message || e}` };
+            codeCells.forEach((c) => {
+                this.#lastOutputs.set(c.getBlockId(), errOut);
+                c.setOutput(errOut);
+            });
+        } finally {
+            codeCells.forEach((c) => c.setRunning(false));
+        }
+    }
+
+    /**
+     * Переприменить сохранённые execution numbers и outputs после re-render (например, move).
+     * Вызывать после каждого `cellList.updateBlocks`.
+     */
+    #reapplyCellState() {
+        this.#execNumbers.forEach((n, id) => {
+            const cell = this.#cellList.getCellByBlockId(id);
+            if (cell && cell.setExecutionNumber) cell.setExecutionNumber(n);
+        });
+        this.#lastOutputs.forEach((out, id) => {
+            const cell = this.#cellList.getCellByBlockId(id);
+            if (cell && cell.setOutput) cell.setOutput(out);
+        });
+    }
+
+    /**
+     * Сохранить актуальное содержимое ячейки на бэк через PUT.
+     * Fire-and-forget (ошибки глотаются) -- бэк может не поддерживать этот endpoint.
+     * @param {number|string} blockId
+     * @param {{getContent: Function}} cell
+     */
+    async #maybeSaveCellContent(blockId, cell) {
+        try {
+            await this.#httpClient.put(`/notebooks/${this.#notebookId}/blocks/${blockId}`, {
+                content: cell.getContent()
+            });
+        } catch {
+            /* tolerate */
+        }
+    }
+
     async #renameNotebook(newTitle) {
         try {
             const response = await this.#httpClient.put(`/notebooks/${this.#notebookId}`, {
@@ -208,10 +276,16 @@ export class BlocksPage {
         }
     }
 
-    /**
-     * Размонтирует все виджеты и очищает DOM.
-     */
     destroy() {
+        // Остановить runner-сессию (fire-and-forget)
+        if (this.#notebookId) {
+            this.#runnerApi.stopSession(this.#notebookId);
+        }
+        // Снять beforeunload listener
+        if (this.#beforeUnloadHandler) {
+            window.removeEventListener('beforeunload', this.#beforeUnloadHandler);
+            this.#beforeUnloadHandler = null;
+        }
         if (this.#cellList) this.#cellList.unmount();
         if (this.#sidebar) this.#sidebar.unmount();
         if (this.#toolbar) this.#toolbar.unmount();

--- a/src/shared/api/RunnerApi.js
+++ b/src/shared/api/RunnerApi.js
@@ -1,0 +1,74 @@
+import { HttpClient } from '../http_client/HttpClient.js';
+
+/**
+ * Тонкая обёртка над HttpClient для runner-эндпоинтов.
+ * Все методы возвращают распакованный `data` из envelope `{data, error}`.
+ */
+export class RunnerApi {
+    #http;
+
+    constructor() {
+        this.#http = HttpClient.getInstance();
+    }
+
+    /**
+     * @param {Response} response
+     * @returns {Promise<*>}
+     */
+    async #parse(response) {
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            const err = body?.error || `HTTP ${response.status}`;
+            throw new Error(err);
+        }
+        return body.data;
+    }
+
+    /**
+     * Исполнить один блок по позиции.
+     * @param {number|string} notebookId
+     * @param {number} blockPosition
+     * @returns {Promise<object>} BlockExecutionResult
+     */
+    async executeBlock(notebookId, blockPosition) {
+        const response = await this.#http.get(
+            `/runner/${notebookId}/block?block_position=${blockPosition}`
+        );
+        return this.#parse(response);
+    }
+
+    /**
+     * Исполнить все блоки начиная с позиции.
+     * @param {number|string} notebookId
+     * @param {number} startPosition
+     * @returns {Promise<object[]>} BlockExecutionResult[]
+     */
+    async executeFromPosition(notebookId, startPosition = 0) {
+        const response = await this.#http.get(
+            `/runner/${notebookId}?block_position=${startPosition}`
+        );
+        return this.#parse(response);
+    }
+
+    /**
+     * Остановить runner-сессию (fire-and-forget, ошибки глотаются).
+     * @param {number|string} notebookId
+     */
+    stopSession(notebookId) {
+        try {
+            return this.#http.get(`/runner/${notebookId}/stop`).catch(() => {});
+        } catch {
+            return Promise.resolve();
+        }
+    }
+
+    /**
+     * Синхронная остановка сессии через sendBeacon для beforeunload.
+     * @param {number|string} notebookId
+     */
+    stopSessionBeacon(notebookId) {
+        if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+            navigator.sendBeacon(`/api/v1/runner/${notebookId}/stop`);
+        }
+    }
+}

--- a/src/shared/components/code-cell/CodeCell.css
+++ b/src/shared/components/code-cell/CodeCell.css
@@ -51,6 +51,13 @@
     background: rgba(2, 115, 104, 0.1);
 }
 
+.code-cell__main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
 .code-cell__editor {
     flex: 1;
     display: flex;
@@ -60,6 +67,51 @@
     border-left: 1px solid var(--cell-border);
     border-radius: 0 6px 6px 0;
     overflow: hidden;
+}
+
+.code-cell__output {
+    border-top: 1px solid var(--cell-border);
+    border-left: 1px solid var(--cell-border);
+    background: var(--code-bg);
+    padding: 8px 12px;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    max-height: 400px;
+    overflow: auto;
+    border-radius: 0 0 6px 0;
+}
+
+.code-cell__output[hidden] {
+    display: none;
+}
+
+.code-cell__output pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--dark-primary);
+}
+
+.code-cell__output pre:empty {
+    display: none;
+}
+
+.code-cell__output-stderr {
+    color: var(--error-red);
+}
+
+.code-cell__output-result {
+    font-weight: 500;
+}
+
+.code-cell--running .code-cell__execution-number::after {
+    content: '*';
+}
+
+.code-cell--running .code-cell__run-btn {
+    opacity: 0.5;
+    pointer-events: none;
 }
 
 .code-cell__line-numbers {
@@ -137,16 +189,4 @@
 
 .code-cell--error {
     border-color: var(--error-red);
-}
-
-.code-cell__error-output {
-    width: 100%;
-    padding: 8px 12px;
-    margin-top: -1px;
-    background: var(--error-bg);
-    border: 1px solid var(--error-red);
-    border-radius: 0 0 6px 6px;
-    font-family: monospace;
-    font-size: 12px;
-    color: var(--error-red);
 }

--- a/src/shared/components/code-cell/CodeCell.js
+++ b/src/shared/components/code-cell/CodeCell.js
@@ -27,6 +27,7 @@ export class CodeCell extends BaseComponent {
 
     /** @type {Function} */
     #onRun;
+    #isRunning = false;
 
     /**
      * @param {HTMLElement} parent
@@ -101,7 +102,7 @@ export class CodeCell extends BaseComponent {
 
         const runBtn = this._element.querySelector('.code-cell__run-btn');
         this._addListener(runBtn, 'click', () => {
-            if (this.#onRun) this.#onRun(this.#blockData.id);
+            if (this.#onRun && !this.#isRunning) this.#onRun(this.#blockData.id);
         });
 
         this._element.querySelectorAll('.code-cell__action-btn').forEach((btn) => {
@@ -152,5 +153,69 @@ export class CodeCell extends BaseComponent {
      */
     getBlockId() {
         return this.#blockData.id;
+    }
+
+    /**
+     * Пометить ячейку как исполняющуюся (или остановленную).
+     * Во время running: Run-кнопка disabled, execution number получает `*`, output очищается.
+     * @param {boolean} isRunning
+     */
+    setRunning(isRunning) {
+        this.#isRunning = isRunning;
+        this._element.classList.toggle('code-cell--running', isRunning);
+        if (isRunning) this.clearOutput();
+    }
+
+    /**
+     * Установить execution number (Jupyter-стиль `[N]`).
+     * @param {number|null} n
+     */
+    setExecutionNumber(n) {
+        const el = this._element.querySelector('.code-cell__execution-number');
+        if (el) el.textContent = `[${n ?? ' '}]`;
+    }
+
+    /**
+     * Показать вывод исполнения ячейки.
+     * Все тексты вставляются через textContent (безопасно, HTML не парсится).
+     * @param {{stdout?: string[], stderr?: string[], result?: string, error?: string}} out
+     */
+    setOutput(out = {}) {
+        const el = this._element.querySelector('.code-cell__output');
+        const stdoutEl = el.querySelector('.code-cell__output-stdout');
+        const stderrEl = el.querySelector('.code-cell__output-stderr');
+        const resultEl = el.querySelector('.code-cell__output-result');
+
+        const hasAny =
+            (out.stdout?.length ?? 0) > 0 ||
+            (out.stderr?.length ?? 0) > 0 ||
+            !!out.result ||
+            !!out.error;
+
+        el.hidden = !hasAny;
+
+        stdoutEl.textContent = out.stdout?.length ? out.stdout.join('\n') : '';
+
+        const stderrText = [out.stderr?.join('\n') || '', out.error || '']
+            .filter(Boolean)
+            .join('\n');
+        stderrEl.textContent = stderrText || '';
+
+        resultEl.textContent = out.result || '';
+
+        this._element.classList.toggle('code-cell--error', !!(out.stderr?.length || out.error));
+    }
+
+    /**
+     * Скрыть и очистить output-область.
+     */
+    clearOutput() {
+        const el = this._element.querySelector('.code-cell__output');
+        if (!el) return;
+        el.hidden = true;
+        el.querySelector('.code-cell__output-stdout').textContent = '';
+        el.querySelector('.code-cell__output-stderr').textContent = '';
+        el.querySelector('.code-cell__output-result').textContent = '';
+        this._element.classList.remove('code-cell--error');
     }
 }

--- a/src/shared/components/code-cell/CodeCell.template.js
+++ b/src/shared/components/code-cell/CodeCell.template.js
@@ -10,9 +10,16 @@ export function CodeCellTemplate(ctx) {
             </svg>
         </button>
     </div>
-    <div class="code-cell__editor">
-        <div class="code-cell__line-numbers"></div>
-        <textarea class="code-cell__textarea" wrap="off" spellcheck="false" placeholder="Введите код...">${escapeHtml(ctx.content)}</textarea>
+    <div class="code-cell__main">
+        <div class="code-cell__editor">
+            <div class="code-cell__line-numbers"></div>
+            <textarea class="code-cell__textarea" wrap="off" spellcheck="false" placeholder="Введите код...">${escapeHtml(ctx.content)}</textarea>
+        </div>
+        <div class="code-cell__output" hidden>
+            <pre class="code-cell__output-stdout"></pre>
+            <pre class="code-cell__output-stderr"></pre>
+            <pre class="code-cell__output-result"></pre>
+        </div>
     </div>
     <div class="code-cell__actions">
         <button class="code-cell__action-btn" data-action="move-up" title="Переместить вверх">

--- a/src/widgets/cell-list/CellList.js
+++ b/src/widgets/cell-list/CellList.js
@@ -1,40 +1,21 @@
-/**
- * @module widgets/cell-list/CellList
- */
-
 import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
 import { CellListTemplate } from './CellList.template.js';
 import { CodeCell } from '../../shared/components/code-cell/CodeCell.js';
 import { TextCell } from '../../shared/components/text-cell/TextCell.js';
 
-/** @typedef {import('../../shared/types.js').BlockData} BlockData */
-
-/**
- * Контейнер ячеек ноутбука. Управляет списком CodeCell/TextCell,
- * их перемещением и копированием содержимого.
- *
- * @extends BaseComponent
- */
 export class CellList extends BaseComponent {
-    /** @type {(CodeCell|TextCell)[]} */
     #cells = [];
-
-    /** @type {BlockData[]} */
     #blocks = [];
+    #onRunCell;
+    #onRerender;
 
-    /**
-     * @param {HTMLElement} parent
-     */
-    constructor(parent) {
+    constructor(parent, { onRunCell, onRerender } = {}) {
         super(null, parent);
+        this.#onRunCell = onRunCell;
+        this.#onRerender = onRerender;
         this.#render();
     }
 
-    /**
-     * Компилирует Handlebars-шаблон CellList и создаёт корневой DOM-элемент контейнера ячеек.
-     *
-     * @private
-     */
     #render() {
         const tempContainer = document.createElement('div');
         tempContainer.innerHTML = CellListTemplate({});
@@ -52,12 +33,6 @@ export class CellList extends BaseComponent {
         super.unmount();
     }
 
-    /**
-     * Заменяет все ячейки новым набором блоков.
-     * Очищает предыдущие, создаёт CodeCell/TextCell по типу и монтирует.
-     *
-     * @param {BlockData[]} blocks -- массив данных блоков
-     */
     updateBlocks(blocks) {
         this.#clearCells();
         this.#blocks = [...blocks];
@@ -68,6 +43,7 @@ export class CellList extends BaseComponent {
         if (blocks.length === 0) {
             container.style.display = 'none';
             emptyState.style.display = '';
+            if (this.#onRerender) this.#onRerender();
             return;
         }
 
@@ -86,7 +62,9 @@ export class CellList extends BaseComponent {
             if (block.type === 'code') {
                 cell = new CodeCell(container, {
                     ...cellCallbacks,
-                    onRun: () => {}
+                    onRun: (id) => {
+                        if (this.#onRunCell) this.#onRunCell(id);
+                    }
                 });
             } else {
                 cell = new TextCell(container, cellCallbacks);
@@ -95,25 +73,15 @@ export class CellList extends BaseComponent {
             cell.mount();
             this.#cells.push(cell);
         });
+
+        if (this.#onRerender) this.#onRerender();
     }
 
-    /**
-     * Добавляет блок в конец списка и перерисовывает все ячейки.
-     *
-     * @param {BlockData} blockData
-     */
     addBlock(blockData) {
         this.#blocks.push(blockData);
         this.updateBlocks(this.#blocks);
     }
 
-    /**
-     * Меняет позицию блока на +-1 и перерисовывает список.
-     *
-     * @private
-     * @param {string} id -- идентификатор перемещаемого блока
-     * @param {number} direction -- направление (-1 вверх, +1 вниз)
-     */
     #moveBlock(id, direction) {
         const index = this.#blocks.findIndex((b) => b.id === id);
         if (index < 0) return;
@@ -128,12 +96,6 @@ export class CellList extends BaseComponent {
         this.updateBlocks(this.#blocks);
     }
 
-    /**
-     * Копирует содержимое блока в буфер обмена.
-     *
-     * @private
-     * @param {string} id -- идентификатор блока
-     */
     #copyBlock(id) {
         const block = this.#blocks.find((b) => b.id === id);
         if (!block) return;
@@ -145,13 +107,42 @@ export class CellList extends BaseComponent {
         navigator.clipboard.writeText(content).catch(() => {});
     }
 
-    /**
-     * Размонтирует все ячейки (CodeCell/TextCell) и очищает внутренний массив.
-     *
-     * @private
-     */
     #clearCells() {
         this.#cells.forEach((cell) => cell.unmount());
         this.#cells = [];
+    }
+
+    /**
+     * Найти ячейку по id блока.
+     * @param {number|string} id
+     * @returns {CodeCell|TextCell|null}
+     */
+    getCellByBlockId(id) {
+        return this.#cells.find((c) => c.getBlockId() === id) || null;
+    }
+
+    /**
+     * Вернуть копию списка всех ячеек.
+     * @returns {Array<CodeCell|TextCell>}
+     */
+    getAllCells() {
+        return [...this.#cells];
+    }
+
+    /**
+     * Вернуть только code-ячейки в порядке позиций.
+     * @returns {CodeCell[]}
+     */
+    getCodeCellsInOrder() {
+        return this.#cells.filter((c) => c instanceof CodeCell);
+    }
+
+    /**
+     * Позиция блока в списке (0-индексированная). Соответствует backend `block_position`.
+     * @param {number|string} id
+     * @returns {number} -1 если не найдено
+     */
+    getBlockPositionById(id) {
+        return this.#blocks.findIndex((b) => b.id === id);
     }
 }


### PR DESCRIPTION
## Что сделано

- Новый `src/shared/api/RunnerApi.js` -- обёртка над HttpClient для эндпоинтов `/runner/*` (executeBlock, executeFromPosition, stopSession, stopSessionBeacon)
- `CodeCell` получил методы `setRunning`, `setExecutionNumber`, `setOutput`, `clearOutput`. Вывод санитизируется через DOMPurify и рендерится как `textContent` внутри трёх `<pre>` панелей (stdout, stderr, result)
- `CellList` принимает коллбэки `onRunCell` и `onRerender`; добавлены геттеры `getCellByBlockId`, `getAllCells`, `getCodeCellsInOrder`, `getBlockPositionById` для использования со страницы
- `BlocksPage` оркестрирует исполнение одного блока и run-all, хранит счётчик исполнений и последние выводы в `Map` по `blockId`, переприменяет их после любого re-render ячеек (move, add, reload). Останавливает runner-сессию при SPA-навигации (`destroy`) и закрытии вкладки (`beforeunload` + `navigator.sendBeacon`)
- Jupyter-стиль счётчика `[N]`; во время исполнения ячейка получает класс `code-cell--running` (пульсирующий `*`, Run-кнопка disabled)
- При ошибке (stderr или network failure) ячейка получает класс `code-cell--error` (красная рамка)
- В CSS добавлены стили `.code-cell__main`, `.code-cell__output`, `.code-cell__output-stderr/-result`, убран устаревший `.code-cell__error-output`
- В `BlocksPage.#createBlock` оставлен маркер `TODO(runner-r)` в месте, где язык блока захардкожен в `'python'`

## Проверки

- `npm run lint` -- чисто (warnings только пре-существующие)
- `npm run format:check` -- чисто
- `npm test` -- 8 Playwright-тестов профиля зелёные
- `act push -j lint` -- lint job локально прошёл

**Автор:** @khosta77