### PR TITLE
feat(frontend): поиск по названиям на странице файлов

### DIFF
--- a/src/pages/files/FilesPage.js
+++ b/src/pages/files/FilesPage.js
@@ -1,11 +1,3 @@
-/**
- * @module pages/files/FilesPage
- *
- * Страница списка ноутбуков (/files).
- * Загружает ноутбуки с пагинацией, поддерживает фильтрацию по владельцу
- * и дате, CRUD-операции над ноутбуками.
- */
-
 import { GreenHeader } from '../../widgets/green-header/GreenHeader.js';
 import { FilterBar } from '../../widgets/filter-bar/FilterBar.js';
 import { FilesTable } from '../../widgets/files-table/FilesTable.js';
@@ -13,40 +5,14 @@ import { Pagination } from '../../shared/components/pagination/Pagination.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { Router } from '../../shared/router/Router.js';
 
-/** @typedef {import('../../shared/types.js').Notebook} Notebook */
-/** @typedef {import('../../shared/types.js').FilterSet} FilterSet */
-/** @typedef {import('../../shared/types.js').FilesPageState} FilesPageState */
-
-/**
- * Страница /files -- список ноутбуков с фильтрами, сортировкой и пагинацией.
- * При отсутствии авторизации редиректит на /sign.
- */
 export class FilesPage {
-    /** @type {HTMLElement} */
     #root;
-
-    /** @type {GreenHeader} */
     #header;
-
-    /** @type {FilterBar} */
     #filterBar;
-
-    /** @type {FilesTable} */
     #filesTable;
-
-    /** @type {Pagination} */
     #pagination;
-
-    /** @type {HttpClient} */
-    #httpClient;
-
-    /** @type {Notebook[]} */
     #allNotebooks = [];
-
-    /** @type {FilterSet} */
-    #filters = { owner: null, dateFrom: null, dateTo: null };
-
-    /** @type {FilesPageState} */
+    #filters = { owner: null, dateFrom: null, dateTo: null, search: '' };
     #state = {
         notebooks: [],
         currentPage: 1,
@@ -54,21 +20,13 @@ export class FilesPage {
         username: ''
     };
 
-    /**
-     * @param {HTMLElement} root -- корневой элемент
-     */
+    #httpClient;
+
     constructor(root) {
         this.#root = root;
         this.#httpClient = HttpClient.getInstance();
     }
 
-    /**
-     * Проверяет авторизацию, рендерит header, фильтры, таблицу и пагинацию,
-     * загружает первую страницу ноутбуков.
-     *
-     * @async
-     * @returns {Promise<void>}
-     */
     async render() {
         this.#root.innerHTML = '';
 
@@ -131,9 +89,6 @@ export class FilesPage {
         await this.#loadNotebooks(1);
     }
 
-    /**
-     * Размонтирует виджеты и очищает DOM.
-     */
     destroy() {
         if (this.#filterBar) this.#filterBar.unmount();
         if (this.#filesTable) this.#filesTable.unmount();
@@ -141,21 +96,18 @@ export class FilesPage {
         this.#root.innerHTML = '';
     }
 
-    /**
-     * Загружает страницу ноутбуков с сервера и обновляет таблицу + пагинатор.
-     *
-     * @private
-     * @async
-     * @param {number} page -- номер страницы (1-based)
-     */
     async #loadNotebooks(page) {
         const requestedPage = Math.max(1, page);
         const offset = (requestedPage - 1) * this.#state.limit;
 
+        const params = new URLSearchParams({
+            limit: String(this.#state.limit),
+            offset: String(offset)
+        });
+        if (this.#filters.search) params.set('search', this.#filters.search);
+
         try {
-            const response = await this.#httpClient.get(
-                `/notebooks?limit=${this.#state.limit}&offset=${offset}`
-            );
+            const response = await this.#httpClient.get(`/notebooks?${params.toString()}`);
 
             if (!response.ok) return;
 
@@ -188,22 +140,17 @@ export class FilesPage {
         }
     }
 
-    /**
-     * Обрабатывает изменение фильтров: мержит новые значения в текущие и перефильтровывает таблицу.
-     *
-     * @private
-     * @param {FilterSet} filters -- изменённые фильтры
-     */
     #onFilterChange(filters) {
+        const searchChanged = 'search' in filters && filters.search !== this.#filters.search;
         Object.assign(this.#filters, filters);
-        this.#applyFilters();
+        if (searchChanged) {
+            // Поиск идёт на бэк, сбрасываем на первую страницу
+            this.#loadNotebooks(1);
+        } else {
+            this.#applyFilters();
+        }
     }
 
-    /**
-     * Фильтрует #allNotebooks по текущим фильтрам (владелец, dateFrom, dateTo) и обновляет таблицу.
-     *
-     * @private
-     */
     #applyFilters() {
         let filtered = [...this.#allNotebooks];
 
@@ -225,12 +172,6 @@ export class FilesPage {
         this.#filesTable.setData(filtered, this.#state.username);
     }
 
-    /**
-     * Создаёт новый ноутбук через POST /notebooks и навигирует к нему.
-     *
-     * @private
-     * @async
-     */
     async #createNotebook() {
         try {
             const response = await this.#httpClient.post('/notebooks', {
@@ -245,11 +186,6 @@ export class FilesPage {
         }
     }
 
-    /**
-     * @private
-     * @async
-     * @param {string} id -- идентификатор ноутбука
-     */
     async #deleteNotebook(id) {
         try {
             const response = await this.#httpClient.delete(`/notebooks/${id}`);
@@ -261,12 +197,6 @@ export class FilesPage {
         }
     }
 
-    /**
-     * @private
-     * @async
-     * @param {string} id -- идентификатор ноутбука
-     * @param {string} newTitle -- новое название
-     */
     async #renameNotebook(id, newTitle) {
         try {
             const response = await this.#httpClient.put(`/notebooks/${id}`, {

--- a/src/widgets/filter-bar/FilterBar.css
+++ b/src/widgets/filter-bar/FilterBar.css
@@ -12,6 +12,39 @@
     gap: 12px;
 }
 
+.filter-bar__search {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.filter-bar__search-icon {
+    position: absolute;
+    left: 10px;
+    color: var(--accent);
+    pointer-events: none;
+}
+
+.filter-bar__search-input {
+    padding: 7px 12px 7px 32px;
+    border: 1px solid var(--cell-border);
+    border-radius: 8px;
+    font-size: 13px;
+    outline: none;
+    width: 220px;
+    color: var(--dark-primary);
+    background: var(--white);
+    transition: border-color 0.15s;
+}
+
+.filter-bar__search-input:focus {
+    border-color: var(--teal-green);
+}
+
+.filter-bar__search-input::placeholder {
+    color: var(--grey);
+}
+
 .filter-bar__dropdown-btn {
     background: var(--light-grey);
     border: none;

--- a/src/widgets/filter-bar/FilterBar.js
+++ b/src/widgets/filter-bar/FilterBar.js
@@ -25,6 +25,7 @@ export class FilterBar extends BaseComponent {
 
     /** @type {boolean} */
     #ownerOpen = false;
+    #searchDebounce = null;
 
     /**
      * @param {HTMLElement} parent
@@ -87,6 +88,15 @@ export class FilterBar extends BaseComponent {
         const createBtn = this._element.querySelector('.filter-bar__create-btn');
         this._addListener(createBtn, 'click', () => {
             this.#onCreate();
+        });
+
+        const searchInput = this._element.querySelector('.filter-bar__search-input');
+        this._addListener(searchInput, 'input', (e) => {
+            clearTimeout(this.#searchDebounce);
+            const value = e.target.value;
+            this.#searchDebounce = setTimeout(() => {
+                if (this.#onFilterChange) this.#onFilterChange({ search: value });
+            }, 200);
         });
 
         const dateBtn = this._element.querySelector('.filter-bar__date-btn');
@@ -270,9 +280,11 @@ export class FilterBar extends BaseComponent {
 
         this._element.querySelector('.filter-bar__date-from').value = '';
         this._element.querySelector('.filter-bar__date-to').value = '';
+        this._element.querySelector('.filter-bar__search-input').value = '';
 
+        clearTimeout(this.#searchDebounce);
         if (this.#onFilterChange) {
-            this.#onFilterChange({ owner: null, dateFrom: null, dateTo: null });
+            this.#onFilterChange({ owner: null, dateFrom: null, dateTo: null, search: '' });
         }
     }
 }

--- a/src/widgets/filter-bar/FilterBar.template.js
+++ b/src/widgets/filter-bar/FilterBar.template.js
@@ -1,6 +1,13 @@
 export function FilterBarTemplate() {
     return `<div class="filter-bar">
     <div class="filter-bar__filters">
+        <div class="filter-bar__search">
+            <svg class="filter-bar__search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="8"/>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+            <input type="text" class="filter-bar__search-input" placeholder="Поиск по названию...">
+        </div>
         <div class="filter-bar__date-wrapper">
             <button class="filter-bar__dropdown-btn filter-bar__date-btn">Изменено</button>
             <div class="filter-bar__date-dropdown">


### PR DESCRIPTION
## Что сделано

- В `FilterBar.hbs` добавлен `.filter-bar__search` с иконкой лупы и `input[type=text]` плейсхолдером \"Поиск по названию...\"
- В `FilterBar.css` добавлены стили `.filter-bar__search`, `.filter-bar__search-icon`, `.filter-bar__search-input` (с focus-стилем и плейсхолдер-цветом)
- `FilterBar.js` получил приватное поле `#searchDebounce` и обработчик `input` на поле поиска с debounce 200мс. При каждом срабатывании эмитится `onFilterChange({ search: value })`
- Кнопка \"Очистить фильтр\" теперь также чистит поле поиска и сбрасывает debounce
- В `FilesPage.js` `#filters` расширен полем `search: ''`
- `#loadNotebooks` строит URL через `URLSearchParams` и добавляет `search`, если он непустой
- `#onFilterChange` различает изменение `search` от остальных фильтров: при изменении `search` делает `#loadNotebooks(1)` (перезагрузка с бэка с сбросом пагинации), иначе применяет client-side фильтры через `#applyFilters`

Зависит от бэкенд-PR go-park-mail-ru/2026_1_KISS#31, который добавляет параметр `?search=` к `GET /notebooks`.

## Проверки

- `npm run lint` -- чисто (warnings только пре-существующие)
- `npm run format:check` -- чисто
- `npm run compile:templates` -- шаблоны скомпилированы
- `npm test` -- 8 Playwright-тестов профиля зелёные
- `act push -j lint` -- lint job локально прошёл

**Автор:** @khosta77