### PR TITLE
feat(frontend): find/replace в ячейках ноутбука

### DIFF
--- a/src/pages/blocks/BlocksPage.js
+++ b/src/pages/blocks/BlocksPage.js
@@ -2,8 +2,10 @@ import { NotebookHeader } from '../../widgets/notebook-header/NotebookHeader.js'
 import { NotebookToolbar } from '../../widgets/notebook-toolbar/NotebookToolbar.js';
 import { NotebookSidebar } from '../../widgets/notebook-sidebar/NotebookSidebar.js';
 import { CellList } from '../../widgets/cell-list/CellList.js';
+import { CodeCell } from '../../shared/components/code-cell/CodeCell.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { RunnerApi } from '../../shared/api/RunnerApi.js';
+import { FindEngine } from '../../shared/search/FindEngine.js';
 import { Router } from '../../shared/router/Router.js';
 
 export class BlocksPage {
@@ -24,6 +26,9 @@ export class BlocksPage {
     #execNumbers = new Map(); // blockId -> execution number
     #lastOutputs = new Map(); // blockId -> output object
     #beforeUnloadHandler = null;
+
+    // Find/Replace state
+    #findEngine = new FindEngine();
 
     constructor(root, params) {
         this.#root = root;
@@ -105,7 +110,13 @@ export class BlocksPage {
         sidebarArea.className = 'blocks-page__sidebar';
         body.appendChild(sidebarArea);
 
-        this.#sidebar = new NotebookSidebar(sidebarArea);
+        this.#sidebar = new NotebookSidebar(sidebarArea, {
+            onFind: (q) => this.#handleFind(q),
+            onNext: (q) => this.#handleFindNav(q, 'next'),
+            onPrev: (q) => this.#handleFindNav(q, 'prev'),
+            onReplace: (q) => this.#handleReplace(q),
+            onReplaceAll: (q) => this.#handleReplaceAll(q)
+        });
         this.#sidebar.mount();
 
         const main = document.createElement('main');
@@ -274,6 +285,90 @@ export class BlocksPage {
         } catch (e) {
             console.error('Failed to rename notebook:', e);
         }
+    }
+
+    /**
+     * Собрать ячейки для поиска в формате, понятном FindEngine.
+     * Читаем живой getContent() (а не this.#notebook.blocks) -- пользователь
+     * мог редактировать ячейки с момента загрузки.
+     * @returns {Array<{id: number|string, kind: 'code'|'text', content: string}>}
+     */
+    #collectSearchableCells() {
+        return this.#cellList.getAllCells().map((c) => ({
+            id: c.getBlockId(),
+            kind: c instanceof CodeCell ? 'code' : 'text',
+            content: c.getContent()
+        }));
+    }
+
+    #handleFind({ query, caseSensitive }) {
+        const cells = this.#collectSearchableCells();
+        const total = this.#findEngine.search(cells, query, caseSensitive);
+        this.#sidebar.setMatchCount(this.#findEngine.index(), total);
+        if (total > 0) this.#focusCurrentMatch();
+    }
+
+    #handleFindNav(query, direction) {
+        if (this.#findEngine.total() === 0) {
+            this.#handleFind(query);
+            return;
+        }
+        const m = direction === 'next' ? this.#findEngine.next() : this.#findEngine.prev();
+        if (m) {
+            this.#sidebar.setMatchCount(this.#findEngine.index(), this.#findEngine.total());
+            this.#focusCurrentMatch();
+        }
+    }
+
+    #focusCurrentMatch() {
+        // Сначала сбросить все highlights в text-ячейках
+        this.#cellList
+            .getAllCells()
+            .filter((c) => typeof c.clearHighlights === 'function')
+            .forEach((c) => c.clearHighlights());
+
+        const m = this.#findEngine.current();
+        if (!m) return;
+        const cell = this.#cellList.getCellByBlockId(m.blockId);
+        if (!cell) return;
+
+        if (m.kind === 'code' && typeof cell.highlightRange === 'function') {
+            cell.highlightRange(m.start, m.end);
+        } else if (m.kind === 'text' && typeof cell.highlightMatch === 'function') {
+            cell.highlightMatch(m.index, m.start, m.end);
+        }
+    }
+
+    #handleReplace({ query, replacement, caseSensitive }) {
+        if (this.#findEngine.total() === 0) {
+            this.#handleFind({ query, caseSensitive });
+            if (this.#findEngine.total() === 0) return;
+        }
+        const m = this.#findEngine.current();
+        if (!m) return;
+        const cell = this.#cellList.getCellByBlockId(m.blockId);
+        if (!cell || typeof cell.setContent !== 'function') return;
+
+        const content = cell.getContent();
+        const updated = content.substring(0, m.start) + replacement + content.substring(m.end);
+        cell.setContent(updated);
+
+        // Пересчитать matches и перейти к следующему
+        this.#handleFind({ query, caseSensitive });
+    }
+
+    #handleReplaceAll({ query, replacement, caseSensitive }) {
+        if (!query) return;
+        const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const re = new RegExp(escaped, caseSensitive ? 'g' : 'gi');
+        for (const cell of this.#cellList.getAllCells()) {
+            if (typeof cell.setContent !== 'function') continue;
+            const original = cell.getContent();
+            const updated = original.replace(re, replacement);
+            if (updated !== original) cell.setContent(updated);
+        }
+        this.#findEngine.reset();
+        this.#sidebar.setMatchCount(-1, 0);
     }
 
     destroy() {

--- a/src/shared/components/code-cell/CodeCell.js
+++ b/src/shared/components/code-cell/CodeCell.js
@@ -148,9 +148,20 @@ export class CodeCell extends BaseComponent {
         return this._element.querySelector('.code-cell__textarea').value;
     }
 
-    /**
-     * @returns {string} идентификатор блока
-     */
+    setContent(text) {
+        const textarea = this._element.querySelector('.code-cell__textarea');
+        textarea.value = text;
+        this.#updateLineNumbers();
+        this.#autoResize();
+    }
+
+    highlightRange(start, end) {
+        const textarea = this._element.querySelector('.code-cell__textarea');
+        textarea.focus({ preventScroll: true });
+        textarea.setSelectionRange(start, end);
+        this._element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
     getBlockId() {
         return this.#blockData.id;
     }

--- a/src/shared/components/text-cell/TextCell.js
+++ b/src/shared/components/text-cell/TextCell.js
@@ -91,9 +91,34 @@ export class TextCell extends BaseComponent {
         return this._element.querySelector('.text-cell__content').textContent;
     }
 
-    /**
-     * @returns {string} идентификатор блока
-     */
+    setContent(text) {
+        this._element.querySelector('.text-cell__content').textContent = text;
+    }
+
+    highlightMatch(_matchIndex, start, end) {
+        const el = this._element.querySelector('.text-cell__content');
+        const raw = el.textContent;
+        const before = raw.substring(0, start);
+        const matchText = raw.substring(start, end);
+        const after = raw.substring(end);
+        el.innerHTML = '';
+        el.appendChild(document.createTextNode(before));
+        const mark = document.createElement('mark');
+        mark.className = 'find-match find-match--current';
+        mark.textContent = matchText;
+        el.appendChild(mark);
+        el.appendChild(document.createTextNode(after));
+        this._element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    clearHighlights() {
+        const el = this._element.querySelector('.text-cell__content');
+        el.querySelectorAll('mark.find-match').forEach((m) => {
+            m.replaceWith(document.createTextNode(m.textContent));
+        });
+        el.normalize();
+    }
+
     getBlockId() {
         return this.#blockData.id;
     }

--- a/src/shared/search/FindEngine.js
+++ b/src/shared/search/FindEngine.js
@@ -1,0 +1,71 @@
+/**
+ * Pure-JS логика поиска по коллекции ячеек.
+ * Без DOM: получает массив `{id, kind, content}`, возвращает индексы совпадений.
+ */
+export class FindEngine {
+    #matches = [];
+    #currentIdx = -1;
+
+    /**
+     * Выполнить поиск по всем ячейкам.
+     * @param {Array<{id: number|string, kind: 'code'|'text', content: string}>} cells
+     * @param {string} query
+     * @param {boolean} caseSensitive
+     * @returns {number} количество совпадений
+     */
+    search(cells, query, caseSensitive) {
+        this.#matches = [];
+        this.#currentIdx = -1;
+        if (!query) return 0;
+
+        for (const cell of cells) {
+            const haystack = caseSensitive ? cell.content : cell.content.toLowerCase();
+            const needle = caseSensitive ? query : query.toLowerCase();
+            let idx = 0;
+            while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+                this.#matches.push({
+                    blockId: cell.id,
+                    kind: cell.kind,
+                    start: idx,
+                    end: idx + query.length
+                });
+                idx += query.length || 1;
+            }
+        }
+        if (this.#matches.length > 0) this.#currentIdx = 0;
+        return this.#matches.length;
+    }
+
+    /** Перейти к следующему совпадению (циклически). */
+    next() {
+        if (this.#matches.length === 0) return null;
+        this.#currentIdx = (this.#currentIdx + 1) % this.#matches.length;
+        return this.current();
+    }
+
+    /** Перейти к предыдущему совпадению (циклически). */
+    prev() {
+        if (this.#matches.length === 0) return null;
+        this.#currentIdx = (this.#currentIdx - 1 + this.#matches.length) % this.#matches.length;
+        return this.current();
+    }
+
+    /** Текущее совпадение. */
+    current() {
+        if (this.#currentIdx < 0) return null;
+        return { ...this.#matches[this.#currentIdx], index: this.#currentIdx };
+    }
+
+    total() {
+        return this.#matches.length;
+    }
+
+    index() {
+        return this.#currentIdx;
+    }
+
+    reset() {
+        this.#matches = [];
+        this.#currentIdx = -1;
+    }
+}

--- a/src/widgets/notebook-sidebar/NotebookSidebar.css
+++ b/src/widgets/notebook-sidebar/NotebookSidebar.css
@@ -81,6 +81,21 @@
     border-color: var(--teal-green);
 }
 
+.notebook-sidebar__checkbox {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--dark-primary);
+    cursor: pointer;
+}
+
+.notebook-sidebar__find-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .notebook-sidebar__find-btn {
     padding: 6px 12px;
     background: var(--teal-green);
@@ -95,19 +110,58 @@
     background: #025e55;
 }
 
+.notebook-sidebar__nav-btn {
+    width: 26px;
+    height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--cell-border);
+    background: var(--white);
+    color: var(--dark-primary);
+    border-radius: 4px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.notebook-sidebar__nav-btn:hover {
+    background: var(--light-grey);
+}
+
+.notebook-sidebar__match-count {
+    font-size: 12px;
+    color: var(--line-number-color);
+    margin-left: auto;
+    user-select: none;
+}
+
 .notebook-sidebar__replace-links {
     display: flex;
-    gap: 16px;
+    gap: 8px;
 }
 
-.notebook-sidebar__link {
-    font-size: 12px;
+.notebook-sidebar__link-btn {
+    padding: 4px 10px;
+    background: transparent;
     color: var(--teal-green);
-    text-decoration: none;
+    border: 1px solid var(--teal-green);
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
 }
 
-.notebook-sidebar__link:hover {
-    text-decoration: underline;
+.notebook-sidebar__link-btn:hover {
+    background: rgba(2, 115, 104, 0.1);
+}
+
+mark.find-match {
+    background: #fff3a0;
+    color: inherit;
+    padding: 0;
+}
+
+mark.find-match--current {
+    background: #ffb84d;
 }
 
 .notebook-sidebar__placeholder {

--- a/src/widgets/notebook-sidebar/NotebookSidebar.js
+++ b/src/widgets/notebook-sidebar/NotebookSidebar.js
@@ -1,33 +1,24 @@
-/**
- * @module widgets/notebook-sidebar/NotebookSidebar
- */
-
 import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
 import { NotebookSidebarTemplate } from './NotebookSidebar.template.js';
 
-/**
- * Боковая панель ноутбука с иконками-кнопками.
- * Открывает/закрывает панели по клику (toggle-логика).
- *
- * @extends BaseComponent
- */
 export class NotebookSidebar extends BaseComponent {
-    /** @type {?string} */
     #activePanel = null;
+    #onFind;
+    #onNext;
+    #onPrev;
+    #onReplace;
+    #onReplaceAll;
 
-    /**
-     * @param {HTMLElement} parent
-     */
-    constructor(parent) {
+    constructor(parent, { onFind, onNext, onPrev, onReplace, onReplaceAll } = {}) {
         super(null, parent);
+        this.#onFind = onFind;
+        this.#onNext = onNext;
+        this.#onPrev = onPrev;
+        this.#onReplace = onReplace;
+        this.#onReplaceAll = onReplaceAll;
         this.#render();
     }
 
-    /**
-     * Компилирует Handlebars-шаблон NotebookSidebar и создаёт корневой DOM-элемент боковой панели.
-     *
-     * @private
-     */
     #render() {
         const tempContainer = document.createElement('div');
         tempContainer.innerHTML = NotebookSidebarTemplate({});
@@ -45,11 +36,23 @@ export class NotebookSidebar extends BaseComponent {
         super.unmount();
     }
 
-    /**
-     * Подключает toggle-обработчики на кнопки sidebar: открытие/закрытие панелей по data-panel атрибуту.
-     *
-     * @private
-     */
+    setMatchCount(currentIdx, total) {
+        const el = this._element.querySelector('.notebook-sidebar__match-count');
+        if (!el) return;
+        el.textContent = total === 0 ? '0 / 0' : `${currentIdx + 1} / ${total}`;
+    }
+
+    getFindQuery() {
+        const findInput = this._element.querySelector('.notebook-sidebar__find-input');
+        const replaceInput = this._element.querySelector('.notebook-sidebar__replace-input');
+        const caseToggle = this._element.querySelector('.notebook-sidebar__case-toggle');
+        return {
+            query: findInput ? findInput.value : '',
+            replacement: replaceInput ? replaceInput.value : '',
+            caseSensitive: caseToggle ? caseToggle.checked : false
+        };
+    }
+
     #attachEvents() {
         this._element.querySelectorAll('.notebook-sidebar__icon-btn').forEach((btn) => {
             this._addListener(btn, 'click', () => {
@@ -62,42 +65,49 @@ export class NotebookSidebar extends BaseComponent {
             });
         });
 
-        this._element.querySelectorAll('.notebook-sidebar__link').forEach((link) => {
-            this._addListener(link, 'click', (e) => {
+        const findInput = this._element.querySelector('.notebook-sidebar__find-input');
+        if (findInput) {
+            this._addListener(findInput, 'keydown', (e) => {
+                if (e.key !== 'Enter') return;
                 e.preventDefault();
+                const q = this.getFindQuery();
+                if (e.shiftKey) {
+                    if (this.#onPrev) this.#onPrev(q);
+                } else if (this.#onNext) {
+                    this.#onNext(q);
+                }
+            });
+        }
+
+        this._element.querySelectorAll('[data-action]').forEach((btn) => {
+            const action = btn.dataset.action;
+            this._addListener(btn, 'click', (e) => {
+                e.preventDefault();
+                const q = this.getFindQuery();
+                if (action === 'find' && this.#onFind) this.#onFind(q);
+                else if (action === 'next' && this.#onNext) this.#onNext(q);
+                else if (action === 'prev' && this.#onPrev) this.#onPrev(q);
+                else if (action === 'replace' && this.#onReplace) this.#onReplace(q);
+                else if (action === 'replace-all' && this.#onReplaceAll) this.#onReplaceAll(q);
             });
         });
     }
 
-    /**
-     * @private
-     * @param {string} panelName -- имя панели из data-panel
-     */
     #openPanel(panelName) {
         this.#closePanel();
         this.#activePanel = panelName;
-
         const btn = this._element.querySelector(`[data-panel="${panelName}"]`);
         if (btn) btn.classList.add('notebook-sidebar__icon-btn--active');
-
         const panel = this._element.querySelector(`.notebook-sidebar__panel--${panelName}`);
         if (panel) panel.classList.add('notebook-sidebar__panel--visible');
     }
 
-    /**
-     * Деактивирует текущую открытую панель: убирает CSS-классы active/visible и сбрасывает #activePanel.
-     *
-     * @private
-     */
     #closePanel() {
         if (!this.#activePanel) return;
-
         const btn = this._element.querySelector(`[data-panel="${this.#activePanel}"]`);
         if (btn) btn.classList.remove('notebook-sidebar__icon-btn--active');
-
         const panel = this._element.querySelector(`.notebook-sidebar__panel--${this.#activePanel}`);
         if (panel) panel.classList.remove('notebook-sidebar__panel--visible');
-
         this.#activePanel = null;
     }
 }

--- a/src/widgets/notebook-sidebar/NotebookSidebar.template.js
+++ b/src/widgets/notebook-sidebar/NotebookSidebar.template.js
@@ -21,12 +21,21 @@ export function NotebookSidebarTemplate() {
     <div class="notebook-sidebar__panel notebook-sidebar__panel--search">
         <h3 class="notebook-sidebar__panel-title">Найти и заменить</h3>
         <div class="notebook-sidebar__panel-content">
-            <input type="text" class="notebook-sidebar__input" placeholder="Найти...">
-            <input type="text" class="notebook-sidebar__input" placeholder="Заменить на...">
-            <button class="notebook-sidebar__find-btn">Найти</button>
+            <input type="text" class="notebook-sidebar__input notebook-sidebar__find-input" placeholder="Найти...">
+            <input type="text" class="notebook-sidebar__input notebook-sidebar__replace-input" placeholder="Заменить на...">
+            <label class="notebook-sidebar__checkbox">
+                <input type="checkbox" class="notebook-sidebar__case-toggle">
+                Учитывать регистр
+            </label>
+            <div class="notebook-sidebar__find-row">
+                <button class="notebook-sidebar__find-btn" data-action="find">Найти</button>
+                <button class="notebook-sidebar__nav-btn" data-action="prev" title="Назад">↑</button>
+                <button class="notebook-sidebar__nav-btn" data-action="next" title="Далее">↓</button>
+                <span class="notebook-sidebar__match-count">0 / 0</span>
+            </div>
             <div class="notebook-sidebar__replace-links">
-                <a href="#" class="notebook-sidebar__link">Заменить</a>
-                <a href="#" class="notebook-sidebar__link">Заменить все</a>
+                <button class="notebook-sidebar__link-btn" data-action="replace">Заменить</button>
+                <button class="notebook-sidebar__link-btn" data-action="replace-all">Заменить все</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Что сделано

- Новый `src/shared/search/FindEngine.js` -- pure-JS класс без DOM, принимает массив `{id, kind, content}`, возвращает список matches `{blockId, kind, start, end}`, умеет `search`, `next`, `prev`, `current`, `total`, `index`, `reset`
- `NotebookSidebar.hbs`: добавлены input для replace, чекбокс \"Учитывать регистр\", кнопки ↑ / ↓ для навигации, счётчик совпадений \"N / M\", кнопки \"Заменить\" и \"Заменить все\" на `data-action`
- `NotebookSidebar.css`: добавлены стили `.notebook-sidebar__checkbox`, `.notebook-sidebar__find-row`, `.notebook-sidebar__nav-btn`, `.notebook-sidebar__match-count`, `.notebook-sidebar__link-btn`, а также `mark.find-match` и `mark.find-match--current` для подсветки в текстовых ячейках
- `NotebookSidebar.js`: принимает callbacks `{onFind, onNext, onPrev, onReplace, onReplaceAll}`, публичные методы `setMatchCount(idx, total)` и `getFindQuery()`. Enter в find-input триггерит Next, Shift+Enter -- Prev. Клики по `[data-action]` диспетчеризуются в соответствующие callbacks
- `CodeCell.js`: публичные методы `setContent(text)` (с пересчётом line numbers и auto-resize) и `highlightRange(start, end)` (через `textarea.setSelectionRange` + `scrollIntoView` -- в textarea нельзя рендерить DOM-mark)
- `TextCell.js`: публичные методы `setContent(text)`, `highlightMatch(i, start, end)` (оборачивает match в `<mark class=\"find-match find-match--current\">` через DOM API, не через innerHTML), `clearHighlights()` (разворачивает все marks обратно в текстовые узлы)
- `BlocksPage.js`: импорт `FindEngine` и `CodeCell`, приватное поле `#findEngine`, методы `#collectSearchableCells` (читает живой `getContent()` с ячеек), `#handleFind`, `#handleFindNav`, `#focusCurrentMatch`, `#handleReplace`, `#handleReplaceAll` (использует escaped regex для case-insensitive замены). Sidebar подключается с полным набором callbacks

Ветка от `feat/develop/code-execution`, потому что требует методы `getAllCells`, `getCellByBlockId` из CellList, добавленные в Фазе 1. После merge Фазы 1 в develop этот PR надо будет перебазировать на develop.

## Проверки

- `npm run lint` -- чисто (warnings только пре-существующие)
- `npm run format:check` -- чисто
- `npm run compile:templates` -- шаблоны скомпилированы
- `npm test` -- 8 Playwright-тестов профиля зелёные
- `act push -j lint` -- lint job локально прошёл

**Автор:** @khosta77