### PR TITLE
feat(EXTRA): HTTPS + domain colkiss.ru

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,12 @@ services:
     container_name: myapp-frontend
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/conf.d/00-logging.conf:/etc/nginx/conf.d/00-logging.conf:ro
       - ./src:/app/src:ro
       - ./public:/app/public:ro
+      - /var/www/certbot:/var/www/certbot:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     restart: unless-stopped

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,19 +1,49 @@
 server {
     listen 80;
-    server_name localhost;
-    access_log /var/log/nginx/access.log debug_proxy;
+    server_name colkiss.ru www.colkiss.ru;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://colkiss.ru$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name www.colkiss.ru;
+
+    ssl_certificate     /etc/letsencrypt/live/colkiss.ru/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/colkiss.ru/privkey.pem;
+
+    return 301 https://colkiss.ru$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name colkiss.ru;
+
+    ssl_certificate     /etc/letsencrypt/live/colkiss.ru/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/colkiss.ru/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     root /app/src;
+    access_log /var/log/nginx/access.log debug_proxy;
 
     server_tokens off;
     autoindex off;
     client_max_body_size 10m;
 
-    # Gzip
     gzip on;
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
     gzip_min_length 256;
 
-    # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
@@ -21,7 +51,6 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';" always;
 
-    # API proxy to backend
     location /api/ {
         proxy_pass http://212.233.96.54:8080;
         proxy_set_header Host $host;
@@ -30,7 +59,6 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Avatar uploads proxy to backend
     location /uploads/ {
         proxy_pass http://212.233.96.54:8080;
         proxy_set_header Host $host;
@@ -39,7 +67,17 @@ server {
         add_header Cache-Control "public, no-transform";
     }
 
-    # Cache static assets
+    location /mail/ {
+        proxy_pass https://127.0.0.1:8443/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_redirect https://127.0.0.1:8443/ /mail/;
+        proxy_read_timeout 90s;
+        proxy_connect_timeout 90s;
+    }
+
     location ~* \.(css|js|svg|png|jpg|jpeg|gif|ico|woff2?)$ {
         try_files $uri =404;
         expires 7d;


### PR DESCRIPTION
## Что сделано
- [x] Nginx: HTTPS server block с сертификатами Let's Encrypt
- [x] Nginx: HTTP -> HTTPS редирект (301)
- [x] Nginx: www.colkiss.ru -> colkiss.ru редирект
- [x] Nginx: ACME challenge location для автообновления сертификатов
- [x] Nginx: блок /mail/ для проксирования Mailcow
- [x] Nginx: HSTS, security headers, gzip
- [x] Docker-compose: порт 443, volumes для certbot и letsencrypt

## Что НЕ в этом PR (делается на сервере)
- Выпуск SSL-сертификата через certbot
- Обновление CORS в бэкенде на `https://colkiss.ru`
- Настройка автообновления сертификата (cron hook)