### PR TITLE
fix(nginx): avatar uploads return 404 due to location priority

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -59,10 +59,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /uploads/ {
+    location ^~ /uploads/ {
         proxy_pass http://212.233.96.54:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         expires 7d;
         add_header Cache-Control "public, no-transform";
     }


### PR DESCRIPTION
## Summary
- Regex location `~* \.(jpg|png|...)$` перехватывал запросы к `/uploads/*.jpg` и возвращал 404 через `try_files`, вместо проксирования на бэкенд
- Добавлен модификатор `^~` к `location /uploads/`, чтобы prefix-location имел приоритет над regex
- Добавлены недостающие proxy-заголовки (`X-Forwarded-For`, `X-Forwarded-Proto`)

## Root Cause
В nginx regex-location (приоритет 3) побеждает обычный prefix-location (приоритет 4). Запрос `GET /uploads/uuid.jpg` попадал в блок для статических файлов, который искал файл в `/app/src/` (контейнер фронтенда), а не проксировал на бэкенд где файл реально хранится.

## Test plan
- [ ] После мержа убедиться что GitHub Actions deploy workflow отработал
- [ ] SSH на сервер: `curl -I https://colkiss.ru/uploads/<uuid>.jpg` -- должен вернуть 200
- [ ] Загрузить аватарку через UI и проверить что она отображается
- [ ] Проверить логи: `docker logs myapp-frontend 2>&1 | grep '/uploads/'` -- должен показать `proxy_to: "212.233.96.54:8080"`