### PR TITLE
fix(nginx): allow blob: in CSP for avatar upload

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -49,7 +49,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self';" always;
 
     location /api/ {
         proxy_pass http://212.233.96.54:8080;


### PR DESCRIPTION
## Summary
- CSP `img-src` не содержал `blob:`, что блокировало `URL.createObjectURL()` при загрузке аватарки
- Браузер блокировал preview изображения и выдавал ошибку "Не удалось прочитать изображение"
- Добавлен `blob:` в `img-src` директиву CSP

## Root Cause
Фронтенд при загрузке аватарки создает blob URL через `URL.createObjectURL(file)` для валидации размеров (квадратность 1:1). CSP заголовок `img-src 'self' data:` не разрешал `blob:` схему, поэтому браузер блокировал загрузку preview-изображения и срабатывал `img.onerror`.

## Test plan
- [ ] Открыть профиль, выбрать изображение для аватарки -- ошибка "Не удалось прочитать" не должна появляться
- [ ] Загрузить квадратное изображение (JPG/PNG/BMP) -- аватарка должна сохраниться и отобразиться
- [ ] Проверить в DevTools что CSP заголовок содержит `blob:` в `img-src`