### PR TITLE
fix(ci): restart container on nginx config change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,5 +39,5 @@ jobs:
               docker compose down
               docker compose up -d
             elif echo "$CHANGED" | grep -q 'nginx/'; then
-              docker exec myapp-frontend nginx -s reload
+              docker compose restart frontend
             fi


### PR DESCRIPTION
## Summary
- `nginx -s reload` не подхватывал изменения конфига из-за inode mismatch при `git pull`
- Заменен на `docker compose restart frontend` который пересоздает bind mount

## Root Cause
Docker bind mount **отдельного файла** привязывается к inode. Git при `pull` заменяет файлы атомарно (новый файл → rename → новый inode). Контейнер продолжает видеть старый файл. `nginx -s reload` перечитывает тот же устаревший файл. `docker compose restart` пересоздает bind mount с правильным inode.

## Test plan
- [ ] Изменить nginx конфиг, замержить в develop
- [ ] Убедиться что после автодеплоя контейнер видит актуальный конфиг: `docker exec myapp-frontend grep <changed-line> /etc/nginx/conf.d/default.conf`