### PR TITLE
fix(runner): extract human-readable messages from execution errors

### DIFF
--- a/src/shared/api/RunnerApi.js
+++ b/src/shared/api/RunnerApi.js
@@ -19,9 +19,27 @@ export class RunnerApi {
         const body = await response.json().catch(() => ({}));
         if (!response.ok) {
             const err = body?.error || `HTTP ${response.status}`;
-            throw new Error(err);
+            throw new Error(this.#formatError(err));
         }
         return body.data;
+    }
+
+    #formatError(raw) {
+        const jsonMatch = raw.match(/:\s*(\{.+\})\s*$/s);
+        if (jsonMatch) {
+            try {
+                const parsed = JSON.parse(jsonMatch[1]);
+                if (Array.isArray(parsed.detail) && parsed.detail.length > 0) {
+                    return parsed.detail
+                        .map((d) => d.msg)
+                        .filter(Boolean)
+                        .join('; ');
+                }
+            } catch {
+                /* fallback */
+            }
+        }
+        return raw;
     }
 
     /**


### PR DESCRIPTION
## Summary
- При ошибке выполнения кода в notebook, бэкенд возвращает сырой JSON от Python runner внутри строки ошибки (например `execution failed with status 422: {"detail":[...]}`)
- Добавлен метод `#formatError()` в `RunnerApi`, который парсит встроенный JSON и извлекает поля `msg` из массива `detail` (формат FastAPI/Pydantic)
- При неудаче парсинга ошибка отображается как раньше (graceful fallback)

## Test plan
- [ ] Открыть notebook, создать пустую code-ячейку, нажать запуск -- ожидать чистое сообщение вместо сырого JSON
- [ ] Ввести `print("Hello")` и запустить -- убедиться что успешный вывод не затронут
- [ ] Проверить `npm run lint` и `npm run format:check` -- 0 errors