### PR TITLE
feat(cell): improve notebook UX — ANSI tracebacks, compact cells, search highlight

### DIFF
--- a/src/shared/api/RunnerApi.js
+++ b/src/shared/api/RunnerApi.js
@@ -19,9 +19,27 @@ export class RunnerApi {
         const body = await response.json().catch(() => ({}));
         if (!response.ok) {
             const err = body?.error || `HTTP ${response.status}`;
-            throw new Error(err);
+            throw new Error(this.#formatError(err));
         }
         return body.data;
+    }
+
+    #formatError(raw) {
+        const jsonMatch = raw.match(/:\s*(\{.+\})\s*$/s);
+        if (jsonMatch) {
+            try {
+                const parsed = JSON.parse(jsonMatch[1]);
+                if (Array.isArray(parsed.detail) && parsed.detail.length > 0) {
+                    return parsed.detail
+                        .map((d) => d.msg)
+                        .filter(Boolean)
+                        .join('; ');
+                }
+            } catch {
+                /* fallback */
+            }
+        }
+        return raw;
     }
 
     /**

--- a/src/shared/components/code-cell/CodeCell.js
+++ b/src/shared/components/code-cell/CodeCell.js
@@ -4,6 +4,7 @@
 
 import { BaseComponent } from '../base-component/BaseComponent.js';
 import { CodeCellTemplate } from './CodeCell.template.js';
+import { ansiToHtml, stripTracebackDashes } from '../../utils/ansiToHtml.js';
 
 /** @typedef {import('../../types.js').BlockData} BlockData */
 
@@ -210,7 +211,7 @@ export class CodeCell extends BaseComponent {
         const stderrText = [out.stderr?.join('\n') || '', out.error || '']
             .filter(Boolean)
             .join('\n');
-        stderrEl.textContent = stderrText || '';
+        stderrEl.innerHTML = stderrText ? ansiToHtml(stripTracebackDashes(stderrText)) : '';
 
         resultEl.textContent = out.result || '';
 
@@ -225,7 +226,7 @@ export class CodeCell extends BaseComponent {
         if (!el) return;
         el.hidden = true;
         el.querySelector('.code-cell__output-stdout').textContent = '';
-        el.querySelector('.code-cell__output-stderr').textContent = '';
+        el.querySelector('.code-cell__output-stderr').innerHTML = '';
         el.querySelector('.code-cell__output-result').textContent = '';
         this._element.classList.remove('code-cell--error');
     }

--- a/src/shared/utils/ansiToHtml.js
+++ b/src/shared/utils/ansiToHtml.js
@@ -1,0 +1,73 @@
+import { escapeHtml } from './escapeHtml.js';
+
+const ANSI_COLORS = {
+    30: '#4E4E4E',
+    31: '#E75C58',
+    32: '#00A250',
+    33: '#DDB62B',
+    34: '#208FFB',
+    35: '#D160C4',
+    36: '#60C6C8',
+    37: '#C5C1B4',
+    90: '#7F7F7F',
+    91: '#F2473F',
+    92: '#00D26B',
+    93: '#F5CF65',
+    94: '#5FB2FF',
+    95: '#E47FFD',
+    96: '#76E3E8',
+    97: '#F7F7F1'
+};
+
+function codeToStyle(code) {
+    if (code === 1) return 'font-weight:bold';
+    if (code === 3) return 'font-style:italic';
+    if (code === 4) return 'text-decoration:underline';
+    if (ANSI_COLORS[code]) return `color:${ANSI_COLORS[code]}`;
+    return null;
+}
+
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[([0-9;]*)m/g;
+
+export function ansiToHtml(text) {
+    ANSI_REGEX.lastIndex = 0;
+    let result = '';
+    let lastIndex = 0;
+    let openSpans = 0;
+    let match;
+
+    while ((match = ANSI_REGEX.exec(text)) !== null) {
+        result += escapeHtml(text.slice(lastIndex, match.index));
+        lastIndex = ANSI_REGEX.lastIndex;
+
+        const codes = match[1].split(';').filter(Boolean).map(Number);
+
+        for (const code of codes) {
+            if (code === 0) {
+                while (openSpans > 0) {
+                    result += '</span>';
+                    openSpans--;
+                }
+            } else {
+                const style = codeToStyle(code);
+                if (style) {
+                    result += `<span style="${style}">`;
+                    openSpans++;
+                }
+            }
+        }
+    }
+
+    result += escapeHtml(text.slice(lastIndex));
+    while (openSpans > 0) {
+        result += '</span>';
+        openSpans--;
+    }
+
+    return result;
+}
+
+export function stripTracebackDashes(text) {
+    return text.replace(/^-{10,}\s*$/gm, '').replace(/\n{3,}/g, '\n\n');
+}


### PR DESCRIPTION
## Summary
- **ANSI traceback rendering**: парсинг ANSI escape-кодов в stderr для Jupyter-like отображения ошибок с цветами. Убраны пунктирные линии-разделители из traceback
- **Compact cells**: уменьшен `min-height` редактора с 96px до 40px -- ячейки с 1-2 строками больше не тратят лишнее место
- **Search highlight color**: цвет выделения при поиске в code-ячейках изменён с голубого на оранжевый (#ffb84d), как в text-ячейках
- **Avatar hint text**: обновлён текст подсказки "Соотношение сторон аватара должно быть 1 к 1"

## Test plan
- [ ] Выполнить код с ошибкой (`print(asda)`) -- traceback с цветами, без `[31m`, без пунктирной линии
- [ ] Создать новую ячейку -- компактная высота
- [ ] Поиск в code-ячейке -- оранжевое выделение
- [ ] Страница профиля -- новый текст подсказки аватарки
- [ ] `npm run lint && npm run format:check` -- 0 errors