### PR TITLE
fix(ui): notebook UI polish — compact cells, menus, cleanup

### DIFF
--- a/src/shared/components/code-cell/CodeCell.css
+++ b/src/shared/components/code-cell/CodeCell.css
@@ -153,6 +153,11 @@
     color: var(--line-number-color);
 }
 
+.code-cell__textarea::selection {
+    background: #ffb84d;
+    color: inherit;
+}
+
 .code-cell__actions {
     position: absolute;
     right: 4px;

--- a/src/shared/components/code-cell/CodeCell.css
+++ b/src/shared/components/code-cell/CodeCell.css
@@ -61,7 +61,7 @@
 .code-cell__editor {
     flex: 1;
     display: flex;
-    min-height: 96px;
+    min-height: 40px;
     min-width: 0;
     background: var(--code-bg);
     border-left: 1px solid var(--cell-border);

--- a/src/widgets/notebook-header/NotebookHeader.css
+++ b/src/widgets/notebook-header/NotebookHeader.css
@@ -132,7 +132,45 @@
     white-space: nowrap;
 }
 
-.notebook-header__menu-item:hover {
+.notebook-header__menu-item:hover,
+.notebook-header__menu-item--active {
     background: var(--light-grey);
     color: var(--dark-primary);
+}
+
+.notebook-header__menu-wrapper {
+    position: relative;
+}
+
+.notebook-header__dropdown {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 100%;
+    background: var(--white);
+    border-radius: 0 0 8px 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    min-width: 180px;
+    overflow: hidden;
+}
+
+.notebook-header__dropdown--open {
+    display: block;
+}
+
+.notebook-header__dropdown-item {
+    display: block;
+    width: 100%;
+    padding: 8px 16px;
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--dark-primary);
+}
+
+.notebook-header__dropdown-item:hover {
+    background: var(--light-grey);
 }

--- a/src/widgets/notebook-header/NotebookHeader.js
+++ b/src/widgets/notebook-header/NotebookHeader.js
@@ -30,6 +30,9 @@ export class NotebookHeader extends BaseComponent {
     /** @type {boolean} */
     #isDropdownOpen = false;
 
+    /** @type {boolean} */
+    #isMenuOpen = false;
+
     /**
      * @param {HTMLElement} parent
      * @param {NotebookHeaderConfig} [config={}]
@@ -83,6 +86,18 @@ export class NotebookHeader extends BaseComponent {
         this._addListener(editBtn, 'click', () => {
             this.#startRename();
         });
+
+        const menuBtn = this._element.querySelector('[data-menu="file"]');
+        if (menuBtn) {
+            this._addListener(menuBtn, 'click', (e) => {
+                e.stopPropagation();
+                this.#toggleMenu();
+            });
+
+            this._addListener(document, 'click', () => {
+                if (this.#isMenuOpen) this.#closeMenu();
+            });
+        }
 
         const pill = this._element.querySelector('.notebook-header__user-pill');
         if (pill) {
@@ -140,6 +155,30 @@ export class NotebookHeader extends BaseComponent {
      *
      * @private
      */
+    #toggleMenu() {
+        this.#isMenuOpen ? this.#closeMenu() : this.#openMenu();
+    }
+
+    #openMenu() {
+        this.#isMenuOpen = true;
+        this._element
+            .querySelector('.notebook-header__dropdown')
+            .classList.add('notebook-header__dropdown--open');
+        this._element
+            .querySelector('[data-menu="file"]')
+            .classList.add('notebook-header__menu-item--active');
+    }
+
+    #closeMenu() {
+        this.#isMenuOpen = false;
+        this._element
+            .querySelector('.notebook-header__dropdown')
+            .classList.remove('notebook-header__dropdown--open');
+        this._element
+            .querySelector('[data-menu="file"]')
+            .classList.remove('notebook-header__menu-item--active');
+    }
+
     #toggleDropdown() {
         this.#isDropdownOpen ? this.#closeDropdown() : this.#openDropdown();
     }

--- a/src/widgets/notebook-header/NotebookHeader.template.js
+++ b/src/widgets/notebook-header/NotebookHeader.template.js
@@ -25,9 +25,6 @@ export function NotebookHeaderTemplate(ctx) {
             </div>
         </div>
         <div class="notebook-header__right">
-            <button class="notebook-header__icon-btn" title="Настройки">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
-            </button>
             ${
                 ctx.user
                     ? `<div class="notebook-header__user-pill-wrapper">

--- a/src/widgets/notebook-header/NotebookHeader.template.js
+++ b/src/widgets/notebook-header/NotebookHeader.template.js
@@ -45,12 +45,14 @@ export function NotebookHeaderTemplate(ctx) {
         </div>
     </div>
     <nav class="notebook-header__menu-bar">
-        <button class="notebook-header__menu-item">Файл</button>
-        <button class="notebook-header__menu-item">Изменить</button>
-        <button class="notebook-header__menu-item">Вид</button>
-        <button class="notebook-header__menu-item">Вставка</button>
-        <button class="notebook-header__menu-item">Среда выполнения</button>
-        <button class="notebook-header__menu-item">Инструменты</button>
+        <div class="notebook-header__menu-wrapper">
+            <button class="notebook-header__menu-item" data-menu="file">Файл</button>
+            <div class="notebook-header__dropdown">
+                <button class="notebook-header__dropdown-item" data-action="open">Открыть</button>
+                <button class="notebook-header__dropdown-item" data-action="save">Сохранить</button>
+                <button class="notebook-header__dropdown-item" data-action="save-as">Сохранить как</button>
+            </div>
+        </div>
     </nav>
 </header>`;
 }

--- a/src/widgets/notebook-toolbar/NotebookToolbar.css
+++ b/src/widgets/notebook-toolbar/NotebookToolbar.css
@@ -1,7 +1,7 @@
 .notebook-toolbar {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     padding: 8px 16px;
     background: var(--white);
     border-bottom: 1px solid var(--cell-border);
@@ -9,35 +9,6 @@
     flex-shrink: 0;
 }
 
-.notebook-toolbar__search {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 12px;
-    border: 1px solid var(--cell-border);
-    border-radius: 6px;
-    background: var(--code-bg);
-    flex: 1;
-    max-width: 320px;
-}
-
-.notebook-toolbar__search-icon {
-    color: var(--line-number-color);
-    flex-shrink: 0;
-}
-
-.notebook-toolbar__search-input {
-    border: none;
-    outline: none;
-    background: transparent;
-    font-size: 13px;
-    color: var(--dark-primary);
-    width: 100%;
-}
-
-.notebook-toolbar__search-input::placeholder {
-    color: var(--line-number-color);
-}
 
 .notebook-toolbar__buttons {
     display: flex;

--- a/src/widgets/notebook-toolbar/NotebookToolbar.template.js
+++ b/src/widgets/notebook-toolbar/NotebookToolbar.template.js
@@ -1,11 +1,5 @@
 export function NotebookToolbarTemplate() {
     return `<div class="notebook-toolbar">
-    <div class="notebook-toolbar__search">
-        <svg class="notebook-toolbar__search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
-        </svg>
-        <input type="text" class="notebook-toolbar__search-input" placeholder="Поиск по ячейкам...">
-    </div>
     <div class="notebook-toolbar__buttons">
         <button class="notebook-toolbar__btn notebook-toolbar__btn--add" data-action="add-code">+ Код</button>
         <button class="notebook-toolbar__btn notebook-toolbar__btn--add" data-action="add-text">+ Текст</button>

--- a/src/widgets/profile-section/ProfileSection.template.js
+++ b/src/widgets/profile-section/ProfileSection.template.js
@@ -11,7 +11,7 @@ export function ProfileSectionTemplate(ctx) {
         <div class="profile-section__avatar-actions">
             <input type="file" class="profile-section__file-input" accept="image/jpeg,image/png,image/bmp" />
             <button class="accent-btn profile-section__upload-btn">Загрузить аватар</button>
-            <span class="profile-section__avatar-hint">JPG, PNG или BMP. Макс. 2 МБ. Изображение должно быть квадратным.</span>
+            <span class="profile-section__avatar-hint">JPG, PNG или BMP. Макс. 2 МБ. Соотношение сторон аватара должно быть 1 к 1.</span>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Уменьшен `min-height` code-ячеек с 96px до 40px -- компактные ячейки для 1-2 строк
- Цвет выделения при поиске в code-ячейках: голубой -> оранжевый (#ffb84d)
- Обновлён текст подсказки аватарки: "Соотношение сторон аватара должно быть 1 к 1"
- Удалено неиспользуемое поле поиска из toolbar (поиск живёт в sidebar)
- Меню-бар: оставлен только "Файл" с dropdown (Открыть, Сохранить, Сохранить как)
- Удалена кнопка шестерёнки (настройки)

## Test plan
- [x] Новая ячейка -- компактная высота (~1 строка)
- [x] 5+ строк кода -- ячейка растягивается
- [x] Поиск в code-ячейке -- оранжевое выделение
- [x] Клик "Файл" -- dropdown с тремя пунктами
- [x] Кнопка шестерёнки отсутствует
- [x] Страница профиля -- новый текст подсказки
- [x] `npm run lint && npm run format:check` -- 0 errors