### PR TITLE
feat: add Service Worker for caching and offline support

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -80,6 +80,14 @@ server {
         proxy_connect_timeout 90s;
     }
 
+    location = /sw.js {
+        try_files $uri =404;
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self';" always;
+    }
+
     location ~* \.(css|js|svg|png|jpg|jpeg|gif|ico|woff2?)$ {
         try_files $uri =404;
         expires 7d;

--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,21 +1,23 @@
 {
-  "name": "",
-  "short_name": "Kiss",
-  "icons": [
-    {
-      "src": "/favicon/web-app-manifest-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/favicon/web-app-manifest-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "display": "standalone"
+    "name": "KISS Colab",
+    "short_name": "Kiss",
+    "start_url": "/files",
+    "id": "/files",
+    "icons": [
+        {
+            "src": "/favicon/web-app-manifest-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "/favicon/web-app-manifest-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "maskable"
+        }
+    ],
+    "theme_color": "#ffffff",
+    "background_color": "#ffffff",
+    "display": "standalone"
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -43,3 +43,9 @@ async function bootstrap() {
 }
 
 bootstrap();
+
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js');
+    });
+}

--- a/src/favicon/site.webmanifest
+++ b/src/favicon/site.webmanifest
@@ -1,21 +1,23 @@
 {
-  "name": "",
-  "short_name": "Kiss",
-  "icons": [
-    {
-      "src": "/favicon/web-app-manifest-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/favicon/web-app-manifest-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "display": "standalone"
+    "name": "KISS Colab",
+    "short_name": "Kiss",
+    "start_url": "/files",
+    "id": "/files",
+    "icons": [
+        {
+            "src": "/favicon/web-app-manifest-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "maskable"
+        },
+        {
+            "src": "/favicon/web-app-manifest-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "maskable"
+        }
+    ],
+    "theme_color": "#ffffff",
+    "background_color": "#ffffff",
+    "display": "standalone"
 }

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,115 @@
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `kiss-${CACHE_VERSION}`;
+
+const PRECACHE_URLS = [
+    '/app/index.html',
+    '/app/index.css',
+    '/app/index.js',
+    '/favicon/site.webmanifest'
+];
+
+function networkFirst(request) {
+    return fetch(request)
+        .then((response) => {
+            if (response.ok) {
+                const clone = response.clone();
+                caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+            }
+            return response;
+        })
+        .catch(() => caches.match('/app/index.html'));
+}
+
+function staleWhileRevalidate(request) {
+    return caches.open(CACHE_NAME).then((cache) =>
+        cache.match(request).then((cached) => {
+            const networkFetch = fetch(request).then((response) => {
+                if (response.ok) {
+                    cache.put(request, response.clone());
+                }
+                return response;
+            });
+            return cached || networkFetch;
+        })
+    );
+}
+
+function cacheFirst(request) {
+    return caches.match(request).then((cached) => {
+        if (cached) return cached;
+        return fetch(request).then((response) => {
+            if (response.ok) {
+                const clone = response.clone();
+                caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+            }
+            return response;
+        });
+    });
+}
+
+function isStaticAsset(pathname) {
+    return (
+        pathname.endsWith('.js') || pathname.endsWith('.css') || pathname.endsWith('.webmanifest')
+    );
+}
+
+function isImageAsset(pathname) {
+    return (
+        pathname.endsWith('.svg') ||
+        pathname.endsWith('.png') ||
+        pathname.endsWith('.jpg') ||
+        pathname.endsWith('.jpeg') ||
+        pathname.endsWith('.ico') ||
+        pathname.endsWith('.gif') ||
+        pathname.endsWith('.woff2') ||
+        pathname.endsWith('.woff')
+    );
+}
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches
+            .open(CACHE_NAME)
+            .then((cache) => cache.addAll(PRECACHE_URLS))
+            .then(() => self.skipWaiting())
+    );
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches
+            .keys()
+            .then((keys) =>
+                Promise.all(
+                    keys
+                        .filter((key) => key.startsWith('kiss-') && key !== CACHE_NAME)
+                        .map((key) => caches.delete(key))
+                )
+            )
+            .then(() => self.clients.claim())
+    );
+});
+
+self.addEventListener('fetch', (event) => {
+    const url = new URL(event.request.url);
+
+    if (event.request.method !== 'GET') return;
+    if (url.origin !== self.location.origin) return;
+    if (url.pathname.startsWith('/api/')) return;
+    if (url.pathname.startsWith('/uploads/')) return;
+
+    if (event.request.mode === 'navigate') {
+        event.respondWith(networkFirst(event.request));
+        return;
+    }
+
+    if (isImageAsset(url.pathname)) {
+        event.respondWith(cacheFirst(event.request));
+        return;
+    }
+
+    if (isStaticAsset(url.pathname)) {
+        event.respondWith(staleWhileRevalidate(event.request));
+        return;
+    }
+});


### PR DESCRIPTION
## Summary
- Добавлен Service Worker (`src/sw.js`) с кешированием статических ассетов и оффлайн-поддержкой SPA-shell
- Pre-cache при установке: `index.html`, `index.css`, `index.js`, `site.webmanifest`
- Стратегии runtime-кеширования: stale-while-revalidate для JS/CSS, cache-first для изображений, network-first для навигации, пропуск для `/api/*` и `/uploads/*`
- Обновлён `site.webmanifest`: заполнено имя приложения ("KISS Colab"), добавлены `start_url` и `id`
- Добавлен `location = /sw.js` в nginx с `no-cache` заголовками (чтобы SW не попал под 7-дневный кеш статики)
