### PR TITLE
Переименовать раздел Редактор в Оформление

### DIFF
--- a/src/pages/profile/ProfilePage.template.js
+++ b/src/pages/profile/ProfilePage.template.js
@@ -10,7 +10,7 @@ export function ProfilePageTemplate() {
             </div>
             <div class="profile-page__sidebar-group">
                 <h3 class="profile-page__sidebar-title">Настройки</h3>
-                <button class="profile-page__sidebar-item" data-section="editor">Редактор</button>
+                <button class="profile-page__sidebar-item" data-section="editor">Оформление</button>
             </div>
             <div class="profile-page__sidebar-group">
                 <h3 class="profile-page__sidebar-title">Опасная зона</h3>


### PR DESCRIPTION
## Summary
- Переименован пункт sidebar "Редактор" → "Оформление" на странице профиля
- Более точное название для раздела с настройками внешнего вида (размер шрифта, табы)

## Test plan
- [x] Открыть /profile → sidebar должен показывать "Оформление" вместо "Редактор"
- [x] Клик по "Оформление" → открывается раздел с настройками шрифта и табов