### PR TITLE
Проверка на дублирующийся email при смене

### DIFF
--- a/src/widgets/profile-section/ProfileSection.js
+++ b/src/widgets/profile-section/ProfileSection.js
@@ -230,6 +230,12 @@ export class ProfileSection extends BaseComponent {
                 return;
             }
 
+            if (newEmail.toLowerCase() === this.#config.user.email.toLowerCase()) {
+                emailMsg.textContent = 'Вы уже используете этот email';
+                emailMsg.style.color = 'var(--error-red)';
+                return;
+            }
+
             try {
                 const response = await this.#httpClient.put('/users/me/email', {
                     new_email: newEmail,


### PR DESCRIPTION
## Summary
- Добавлена клиентская проверка: если пользователь вводит тот же email, что уже привязан к аккаунту, показывается сообщение "Вы уже используете этот email"
- Сравнение case-insensitive
- Не отправляет запрос к серверу в этом случае

## Test plan
- [x] Открыть /profile → форма смены email
- [x] Ввести текущий email, пароль, нажать "Сменить" → сообщение "Вы уже используете этот email"
- [x] Ввести новый email → запрос уходит на сервер как обычно