### PR TITLE
Перенести кнопку удаления аккаунта в профиль, убрать Опасную зону

### DIFF
--- a/src/pages/profile/ProfilePage.js
+++ b/src/pages/profile/ProfilePage.js
@@ -3,7 +3,6 @@ import { ProfileSection } from '../../widgets/profile-section/ProfileSection.js'
 import { PasswordSection } from '../../widgets/password-section/PasswordSection.js';
 import { SubscriptionSection } from '../../widgets/subscription-section/SubscriptionSection.js';
 import { EditorSettings } from '../../widgets/editor-settings/EditorSettings.js';
-import { DangerZone } from '../../widgets/danger-zone/DangerZone.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { Router } from '../../shared/router/Router.js';
 import { ProfilePageTemplate } from './ProfilePage.template.js';
@@ -12,8 +11,7 @@ const SECTION_MAP = {
     profile: ProfileSection,
     password: PasswordSection,
     subscription: SubscriptionSection,
-    editor: EditorSettings,
-    danger: DangerZone
+    editor: EditorSettings
 };
 
 /**

--- a/src/pages/profile/ProfilePage.template.js
+++ b/src/pages/profile/ProfilePage.template.js
@@ -12,10 +12,6 @@ export function ProfilePageTemplate() {
                 <h3 class="profile-page__sidebar-title">Настройки</h3>
                 <button class="profile-page__sidebar-item" data-section="editor">Редактор</button>
             </div>
-            <div class="profile-page__sidebar-group">
-                <h3 class="profile-page__sidebar-title">Опасная зона</h3>
-                <button class="profile-page__sidebar-item profile-page__sidebar-item--danger" data-section="danger">Удаление аккаунта</button>
-            </div>
         </nav>
         <div class="profile-page__content"></div>
     </div>

--- a/src/widgets/profile-section/ProfileSection.scss
+++ b/src/widgets/profile-section/ProfileSection.scss
@@ -184,3 +184,25 @@
 .profile-section__info-label {
     font-weight: 600;
 }
+
+.profile-section__delete-section {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.profile-section__delete-btn {
+    background: none;
+    border: 1px solid #9ca3af;
+    color: #9ca3af;
+    padding: 6px 16px;
+    border-radius: 6px;
+    cursor: not-allowed;
+    font-size: 13px;
+    font-family: inherit;
+}
+
+.profile-section__delete-notice {
+    font-size: 12px;
+    color: #9ca3af;
+}

--- a/src/widgets/profile-section/ProfileSection.template.js
+++ b/src/widgets/profile-section/ProfileSection.template.js
@@ -58,5 +58,11 @@ export function ProfileSectionTemplate(ctx) {
         <span class="profile-section__info-label">Дата регистрации:</span>
         <span class="profile-section__info-value">${escapeHtml(ctx.createdAt)}</span>
     </div>
+
+    <hr class="profile-section__divider" />
+    <div class="profile-section__delete-section">
+        <button class="profile-section__delete-btn" disabled>Удалить аккаунт</button>
+        <span class="profile-section__delete-notice">Функция временно недоступна</span>
+    </div>
 </div>`;
 }


### PR DESCRIPTION
## Summary
- Удален раздел "Опасная зона" из sidebar настроек профиля
- Кнопка "Удалить аккаунт" (disabled, серая) перенесена в конец раздела "Профиль"
- Деструктивные действия больше не на видном месте

## Test plan
- [ ] Открыть /profile → sidebar: только "Аккаунт" и "Настройки", без "Опасная зона"
- [ ] Прокрутить раздел "Профиль" вниз → серая кнопка "Удалить аккаунт" с пометкой "Функция временно недоступна"
- [ ] Кнопка disabled, не кликабельна