### PR TITLE
Улучшить UX формы смены email

### DIFF
--- a/src/widgets/profile-section/ProfileSection.js
+++ b/src/widgets/profile-section/ProfileSection.js
@@ -205,8 +205,13 @@ export class ProfileSection extends BaseComponent {
 
         this._addListener(changeBtn, 'click', () => {
             emailForm.classList.toggle('profile-section__email-form--hidden');
-            if (!emailForm.classList.contains('profile-section__email-form--hidden')) {
+            const isHidden = emailForm.classList.contains('profile-section__email-form--hidden');
+            changeBtn.textContent = isHidden ? 'Изменить email' : 'Отмена';
+            if (!isHidden) {
                 passwordInput.mount();
+                passwordInput.clear();
+                const pwdEl = passwordWrap.querySelector('.input-field');
+                if (pwdEl) pwdEl.setAttribute('autocomplete', 'new-password');
             } else {
                 passwordInput.unmount();
             }

--- a/src/widgets/profile-section/ProfileSection.template.js
+++ b/src/widgets/profile-section/ProfileSection.template.js
@@ -47,7 +47,10 @@ export function ProfileSectionTemplate(ctx) {
                 <label class="profile-section__label">Новый email</label>
                 <input type="email" class="profile-section__input" data-field="new_email" placeholder="Новый email" />
             </div>
-            <div class="profile-section__email-password-wrap"></div>
+            <div class="profile-section__field">
+                <label class="profile-section__label">Текущий пароль (для подтверждения)</label>
+                <div class="profile-section__email-password-wrap"></div>
+            </div>
             <button class="accent-btn profile-section__email-save-btn">Сменить email</button>
             <span class="profile-section__email-msg"></span>
         </div>


### PR DESCRIPTION
## Summary
- Добавлен лейбл "Текущий пароль (для подтверждения)" к полю пароля в форме смены email
- Кнопка-toggle меняет текст: "Изменить email" ↔ "Отмена"
- При открытии формы поле пароля очищается и не автозаполняется браузером
- Убрана визуальная дублирование двух кнопок с похожим текстом

## Test plan
- [ ] Открыть форму смены email → лейбл "Текущий пароль (для подтверждения)" виден
- [ ] Кнопка показывает "Отмена" когда форма открыта, "Изменить email" когда закрыта
- [ ] Пароль не автозаполняется браузером
- [ ] При повторном открытии формы поле пароля пустое