### PR TITLE
Добавить кнопку удаления ячейки

### DIFF
--- a/src/pages/blocks/BlocksPage.js
+++ b/src/pages/blocks/BlocksPage.js
@@ -125,7 +125,8 @@ export class BlocksPage {
 
         this.#cellList = new CellList(main, {
             onRunCell: (blockId) => this.#runSingleBlock(blockId),
-            onRerender: () => this.#reapplyCellState()
+            onRerender: () => this.#reapplyCellState(),
+            onDeleteCell: (blockId) => this.#deleteBlock(blockId)
         });
         this.#cellList.mount();
 
@@ -163,6 +164,25 @@ export class BlocksPage {
             this.#cellList.updateBlocks(notebook.blocks || []);
         } catch (e) {
             console.error('Failed to create block:', e);
+        }
+    }
+
+    async #deleteBlock(blockId) {
+        try {
+            const response = await this.#httpClient.delete(
+                `/notebooks/${this.#notebookId}/blocks/${blockId}`
+            );
+            if (!response.ok) return;
+
+            const reloadResponse = await this.#httpClient.get(`/notebooks/${this.#notebookId}`);
+            if (!reloadResponse.ok) return;
+            const { data: notebook } = await reloadResponse.json();
+            this.#notebook = notebook;
+            this.#cellList.updateBlocks(notebook.blocks || []);
+            this.#execNumbers.delete(blockId);
+            this.#lastOutputs.delete(blockId);
+        } catch (e) {
+            console.error('Failed to delete block:', e);
         }
     }
 

--- a/src/shared/components/code-cell/CodeCell.js
+++ b/src/shared/components/code-cell/CodeCell.js
@@ -27,6 +27,9 @@ export class CodeCell extends BaseComponent {
     #onCopy;
 
     /** @type {Function} */
+    #onDelete;
+
+    /** @type {Function} */
     #onRun;
     #isRunning = false;
 
@@ -39,12 +42,13 @@ export class CodeCell extends BaseComponent {
      * @param {Function} [options.onCopy] -- вызывается при копировании
      * @param {Function} [options.onRun] -- вызывается при запуске кода
      */
-    constructor(parent, { blockData, onMoveUp, onMoveDown, onCopy, onRun }) {
+    constructor(parent, { blockData, onMoveUp, onMoveDown, onCopy, onDelete, onRun }) {
         super(null, parent);
         this.#blockData = blockData;
         this.#onMoveUp = onMoveUp;
         this.#onMoveDown = onMoveDown;
         this.#onCopy = onCopy;
+        this.#onDelete = onDelete;
         this.#onRun = onRun;
         this.#render();
     }
@@ -113,6 +117,7 @@ export class CodeCell extends BaseComponent {
                 if (action === 'move-down' && this.#onMoveDown)
                     this.#onMoveDown(this.#blockData.id);
                 if (action === 'copy' && this.#onCopy) this.#onCopy(this.#blockData.id);
+                if (action === 'delete' && this.#onDelete) this.#onDelete(this.#blockData.id);
             });
         });
     }

--- a/src/shared/components/code-cell/CodeCell.scss
+++ b/src/shared/components/code-cell/CodeCell.scss
@@ -135,6 +135,10 @@
     color: var(--dark-primary);
 }
 
+.code-cell__action-btn--delete:hover {
+    color: var(--error-red);
+}
+
 .code-cell--error {
     border-color: var(--error-red);
 }

--- a/src/shared/components/code-cell/CodeCell.template.js
+++ b/src/shared/components/code-cell/CodeCell.template.js
@@ -31,6 +31,9 @@ export function CodeCellTemplate(ctx) {
         <button class="code-cell__action-btn" data-action="copy" title="Копировать">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
         </button>
+        <button class="code-cell__action-btn code-cell__action-btn--delete" data-action="delete" title="Удалить">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/></svg>
+        </button>
     </div>
 </div>`;
 }

--- a/src/shared/components/text-cell/TextCell.js
+++ b/src/shared/components/text-cell/TextCell.js
@@ -25,6 +25,9 @@ export class TextCell extends BaseComponent {
     /** @type {Function} */
     #onCopy;
 
+    /** @type {Function} */
+    #onDelete;
+
     /**
      * @param {HTMLElement} parent
      * @param {Object} options
@@ -32,13 +35,15 @@ export class TextCell extends BaseComponent {
      * @param {Function} [options.onMoveUp] -- вызывается при перемещении вверх
      * @param {Function} [options.onMoveDown] -- вызывается при перемещении вниз
      * @param {Function} [options.onCopy] -- вызывается при копировании
+     * @param {Function} [options.onDelete] -- вызывается при удалении
      */
-    constructor(parent, { blockData, onMoveUp, onMoveDown, onCopy }) {
+    constructor(parent, { blockData, onMoveUp, onMoveDown, onCopy, onDelete }) {
         super(null, parent);
         this.#blockData = blockData;
         this.#onMoveUp = onMoveUp;
         this.#onMoveDown = onMoveDown;
         this.#onCopy = onCopy;
+        this.#onDelete = onDelete;
         this.#render();
     }
 
@@ -80,6 +85,7 @@ export class TextCell extends BaseComponent {
                 if (action === 'move-down' && this.#onMoveDown)
                     this.#onMoveDown(this.#blockData.id);
                 if (action === 'copy' && this.#onCopy) this.#onCopy(this.#blockData.id);
+                if (action === 'delete' && this.#onDelete) this.#onDelete(this.#blockData.id);
             });
         });
     }

--- a/src/shared/components/text-cell/TextCell.scss
+++ b/src/shared/components/text-cell/TextCell.scss
@@ -69,3 +69,7 @@
     background: var(--light-grey);
     color: var(--dark-primary);
 }
+
+.text-cell__action-btn--delete:hover {
+    color: var(--error-red);
+}

--- a/src/shared/components/text-cell/TextCell.template.js
+++ b/src/shared/components/text-cell/TextCell.template.js
@@ -13,6 +13,9 @@ export function TextCellTemplate(ctx) {
         <button class="text-cell__action-btn" data-action="copy" title="Копировать">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
         </button>
+        <button class="text-cell__action-btn text-cell__action-btn--delete" data-action="delete" title="Удалить">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/></svg>
+        </button>
     </div>
 </div>`;
 }

--- a/src/widgets/cell-list/CellList.js
+++ b/src/widgets/cell-list/CellList.js
@@ -8,11 +8,13 @@ export class CellList extends BaseComponent {
     #blocks = [];
     #onRunCell;
     #onRerender;
+    #onDeleteCell;
 
-    constructor(parent, { onRunCell, onRerender } = {}) {
+    constructor(parent, { onRunCell, onRerender, onDeleteCell } = {}) {
         super(null, parent);
         this.#onRunCell = onRunCell;
         this.#onRerender = onRerender;
+        this.#onDeleteCell = onDeleteCell;
         this.#render();
     }
 
@@ -55,7 +57,10 @@ export class CellList extends BaseComponent {
                 blockData: block,
                 onMoveUp: (id) => this.#moveBlock(id, -1),
                 onMoveDown: (id) => this.#moveBlock(id, 1),
-                onCopy: (id) => this.#copyBlock(id)
+                onCopy: (id) => this.#copyBlock(id),
+                onDelete: (id) => {
+                    if (this.#onDeleteCell) this.#onDeleteCell(id);
+                }
             };
 
             let cell;


### PR DESCRIPTION
## Summary
- Добавлена кнопка удаления (иконка урны) в панель действий CodeCell и TextCell
- При клике вызывается `DELETE /api/v1/notebooks/{id}/blocks/{blockId}` (endpoint уже существует на бэкенде)
- После удаления блокнот перезагружается, execution state очищается для удаленного блока
- Hover-эффект: красный цвет иконки

## Test plan
- [ ] Навести на ячейку → видна кнопка с урной
- [ ] Кликнуть урну на code-ячейке → ячейка удалена
- [ ] Кликнуть урну на text-ячейке → ячейка удалена
- [ ] После удаления остальные ячейки и их вывод сохранены