### PR TITLE
Обработка ANSI-кодов в stdout и carriage returns для pip install

### DIFF
--- a/src/shared/components/code-cell/CodeCell.js
+++ b/src/shared/components/code-cell/CodeCell.js
@@ -4,11 +4,7 @@
 
 import { BaseComponent } from '../base-component/BaseComponent.js';
 import { CodeCellTemplate } from './CodeCell.template.js';
-import {
-    ansiToHtml,
-    stripTracebackDashes,
-    handleCarriageReturns
-} from '../../utils/ansiToHtml.js';
+import { ansiToHtml, stripTracebackDashes, handleCarriageReturns } from '../../utils/ansiToHtml.js';
 
 /** @typedef {import('../../types.js').BlockData} BlockData */
 

--- a/src/shared/components/code-cell/CodeCell.js
+++ b/src/shared/components/code-cell/CodeCell.js
@@ -4,7 +4,11 @@
 
 import { BaseComponent } from '../base-component/BaseComponent.js';
 import { CodeCellTemplate } from './CodeCell.template.js';
-import { ansiToHtml, stripTracebackDashes } from '../../utils/ansiToHtml.js';
+import {
+    ansiToHtml,
+    stripTracebackDashes,
+    handleCarriageReturns
+} from '../../utils/ansiToHtml.js';
 
 /** @typedef {import('../../types.js').BlockData} BlockData */
 
@@ -211,12 +215,15 @@ export class CodeCell extends BaseComponent {
 
         el.hidden = !hasAny;
 
-        stdoutEl.textContent = out.stdout?.length ? out.stdout.join('\n') : '';
+        const stdoutText = out.stdout?.length ? out.stdout.join('\n') : '';
+        stdoutEl.innerHTML = stdoutText ? ansiToHtml(handleCarriageReturns(stdoutText)) : '';
 
         const stderrText = [out.stderr?.join('\n') || '', out.error || '']
             .filter(Boolean)
             .join('\n');
-        stderrEl.innerHTML = stderrText ? ansiToHtml(stripTracebackDashes(stderrText)) : '';
+        stderrEl.innerHTML = stderrText
+            ? ansiToHtml(handleCarriageReturns(stripTracebackDashes(stderrText)))
+            : '';
 
         resultEl.textContent = out.result || '';
 
@@ -230,7 +237,7 @@ export class CodeCell extends BaseComponent {
         const el = this._element.querySelector('.code-cell__output');
         if (!el) return;
         el.hidden = true;
-        el.querySelector('.code-cell__output-stdout').textContent = '';
+        el.querySelector('.code-cell__output-stdout').innerHTML = '';
         el.querySelector('.code-cell__output-stderr').innerHTML = '';
         el.querySelector('.code-cell__output-result').textContent = '';
         this._element.classList.remove('code-cell--error');

--- a/src/shared/utils/ansiToHtml.js
+++ b/src/shared/utils/ansiToHtml.js
@@ -71,3 +71,13 @@ export function ansiToHtml(text) {
 export function stripTracebackDashes(text) {
     return text.replace(/^-{10,}\s*$/gm, '').replace(/\n{3,}/g, '\n\n');
 }
+
+export function handleCarriageReturns(text) {
+    return text
+        .split('\n')
+        .map((line) => {
+            const parts = line.split('\r');
+            return parts[parts.length - 1];
+        })
+        .join('\n');
+}


### PR DESCRIPTION
## Summary
- stdout теперь обрабатывается через `ansiToHtml()` (раньше plain textContent -- ANSI-коды были видны как текст)
- Добавлена `handleCarriageReturns()` для корректного отображения progress bars (pip использует `\r` для перезаписи строк, что приводило к задвоенному тексту)
- stderr тоже обрабатывается через `handleCarriageReturns()`

## Test plan
- [ ] Выполнить `!pip install matplotlib` → вывод с цветами, без задвоенных progress bars
- [ ] Обычный `print()` с ANSI-кодами → цвета отображаются
- [ ] Python tracebacks → по-прежнему корректно форматируются