### PR TITLE
Исправить потерю содержимого текстовых ячеек при ререндере

### DIFF
--- a/src/pages/blocks/BlocksPage.js
+++ b/src/pages/blocks/BlocksPage.js
@@ -126,7 +126,8 @@ export class BlocksPage {
         this.#cellList = new CellList(main, {
             onRunCell: (blockId) => this.#runSingleBlock(blockId),
             onRerender: () => this.#reapplyCellState(),
-            onDeleteCell: (blockId) => this.#deleteBlock(blockId)
+            onDeleteCell: (blockId) => this.#deleteBlock(blockId),
+            onSaveContent: (blockId, content) => this.#saveTextCellContent(blockId, content)
         });
         this.#cellList.mount();
 
@@ -142,7 +143,27 @@ export class BlocksPage {
         window.addEventListener('beforeunload', this.#beforeUnloadHandler);
     }
 
+    async #saveTextCellContent(blockId, content) {
+        try {
+            await this.#httpClient.put(`/notebooks/${this.#notebookId}/blocks/${blockId}`, {
+                content
+            });
+        } catch {
+            /* tolerate */
+        }
+    }
+
+    async #saveAllTextCells() {
+        const allCells = this.#cellList.getAllCells();
+        for (const cell of allCells) {
+            if (!(cell instanceof CodeCell)) {
+                await this.#maybeSaveCellContent(cell.getBlockId(), cell);
+            }
+        }
+    }
+
     async #createBlock(type) {
+        await this.#saveAllTextCells();
         try {
             const body = { type, content: '' };
             if (type === 'code') {

--- a/src/shared/components/text-cell/TextCell.js
+++ b/src/shared/components/text-cell/TextCell.js
@@ -28,6 +28,9 @@ export class TextCell extends BaseComponent {
     /** @type {Function} */
     #onDelete;
 
+    /** @type {Function} */
+    #onContentChange;
+
     /**
      * @param {HTMLElement} parent
      * @param {Object} options
@@ -36,14 +39,16 @@ export class TextCell extends BaseComponent {
      * @param {Function} [options.onMoveDown] -- вызывается при перемещении вниз
      * @param {Function} [options.onCopy] -- вызывается при копировании
      * @param {Function} [options.onDelete] -- вызывается при удалении
+     * @param {Function} [options.onContentChange] -- вызывается при потере фокуса (сохранение)
      */
-    constructor(parent, { blockData, onMoveUp, onMoveDown, onCopy, onDelete }) {
+    constructor(parent, { blockData, onMoveUp, onMoveDown, onCopy, onDelete, onContentChange }) {
         super(null, parent);
         this.#blockData = blockData;
         this.#onMoveUp = onMoveUp;
         this.#onMoveDown = onMoveDown;
         this.#onCopy = onCopy;
         this.#onDelete = onDelete;
+        this.#onContentChange = onContentChange;
         this.#render();
     }
 
@@ -87,6 +92,13 @@ export class TextCell extends BaseComponent {
                 if (action === 'copy' && this.#onCopy) this.#onCopy(this.#blockData.id);
                 if (action === 'delete' && this.#onDelete) this.#onDelete(this.#blockData.id);
             });
+        });
+
+        const contentEl = this._element.querySelector('.text-cell__content');
+        this._addListener(contentEl, 'blur', () => {
+            if (this.#onContentChange) {
+                this.#onContentChange(this.#blockData.id, contentEl.textContent);
+            }
         });
     }
 

--- a/src/widgets/cell-list/CellList.js
+++ b/src/widgets/cell-list/CellList.js
@@ -9,12 +9,14 @@ export class CellList extends BaseComponent {
     #onRunCell;
     #onRerender;
     #onDeleteCell;
+    #onSaveContent;
 
-    constructor(parent, { onRunCell, onRerender, onDeleteCell } = {}) {
+    constructor(parent, { onRunCell, onRerender, onDeleteCell, onSaveContent } = {}) {
         super(null, parent);
         this.#onRunCell = onRunCell;
         this.#onRerender = onRerender;
         this.#onDeleteCell = onDeleteCell;
+        this.#onSaveContent = onSaveContent;
         this.#render();
     }
 
@@ -72,7 +74,12 @@ export class CellList extends BaseComponent {
                     }
                 });
             } else {
-                cell = new TextCell(container, cellCallbacks);
+                cell = new TextCell(container, {
+                    ...cellCallbacks,
+                    onContentChange: (id, content) => {
+                        if (this.#onSaveContent) this.#onSaveContent(id, content);
+                    }
+                });
             }
 
             cell.mount();
@@ -87,12 +94,23 @@ export class CellList extends BaseComponent {
         this.updateBlocks(this.#blocks);
     }
 
+    #syncTextCellsToBlocks() {
+        for (const cell of this.#cells) {
+            if (cell instanceof TextCell) {
+                const block = this.#blocks.find((b) => b.id === cell.getBlockId());
+                if (block) block.content = cell.getContent();
+            }
+        }
+    }
+
     #moveBlock(id, direction) {
         const index = this.#blocks.findIndex((b) => b.id === id);
         if (index < 0) return;
 
         const newIndex = index + direction;
         if (newIndex < 0 || newIndex >= this.#blocks.length) return;
+
+        this.#syncTextCellsToBlocks();
 
         const temp = this.#blocks[index];
         this.#blocks[index] = this.#blocks[newIndex];


### PR DESCRIPTION
## Summary
- **Корневая причина**: TextCell использует contenteditable, но не сохраняет изменения. При любом ререндере (перемещение, добавление блока) DOM-контент терялся
- TextCell: добавлен `blur`-обработчик, вызывающий `PUT /notebooks/{id}/blocks/{blockId}` для сохранения
- CellList: при перемещении ячейки DOM-контент синхронизируется в `#blocks` массив перед пересозданием
- BlocksPage: перед созданием нового блока сохраняются все текстовые ячейки на сервер

## Test plan
- [ ] Написать текст в TextCell, кликнуть вне → перезагрузить страницу → текст сохранен
- [ ] Написать текст, переместить ячейку вверх/вниз → текст не потерян
- [ ] Написать текст, добавить новый блок → текст не потерян
- [ ] Редактирование code-ячеек работает как прежде