### PR TITLE
[MULTI] Не перезатирать успешные ячейки при ошибке Run All

### DIFF
--- a/src/pages/blocks/BlocksPage.js
+++ b/src/pages/blocks/BlocksPage.js
@@ -234,8 +234,11 @@ export class BlocksPage {
         } catch (e) {
             const errOut = { error: `Run-all failed: ${e.message || e}` };
             codeCells.forEach((c) => {
-                this.#lastOutputs.set(c.getBlockId(), errOut);
-                c.setOutput(errOut);
+                const blockId = c.getBlockId();
+                if (!this.#lastOutputs.has(blockId)) {
+                    this.#lastOutputs.set(blockId, errOut);
+                    c.setOutput(errOut);
+                }
             });
         } finally {
             codeCells.forEach((c) => c.setRunning(false));


### PR DESCRIPTION
## Summary
- Парный PR к go-park-mail-ru/2026_1_KISS#40
- При ошибке Run All catch-блок теперь проверяет, есть ли у ячейки уже сохраненный вывод
- Ячейки, получившие корректные результаты из partial response бэкенда, не заменяются generic-ошибкой

## Test plan
- [ ] Run All с 3 ячейками: print("hello"), raise Exception, print("world")
- [ ] Ячейка 1: зеленый вывод "hello"
- [ ] Ячейка 2: красная ошибка
- [ ] Ячейка 3: generic "Run-all failed" (не выполнилась)