### PR TITLE
[MULTI] Убрать ограничение 1:1 для загрузки аватара

### DIFF
--- a/src/widgets/profile-section/ProfileSection.js
+++ b/src/widgets/profile-section/ProfileSection.js
@@ -99,12 +99,6 @@ export class ProfileSection extends BaseComponent {
             img.onload = async () => {
                 URL.revokeObjectURL(objectUrl);
 
-                if (img.width !== img.height) {
-                    errorEl.textContent = 'Изображение должно быть квадратным (1:1)';
-                    fileInput.value = '';
-                    return;
-                }
-
                 try {
                     const response = await this.#httpClient.upload('/users/me/avatar', file);
                     const result = await response.json();

--- a/src/widgets/profile-section/ProfileSection.template.js
+++ b/src/widgets/profile-section/ProfileSection.template.js
@@ -11,7 +11,7 @@ export function ProfileSectionTemplate(ctx) {
         <div class="profile-section__avatar-actions">
             <input type="file" class="profile-section__file-input" accept="image/jpeg,image/png,image/bmp" />
             <button class="accent-btn profile-section__upload-btn">Загрузить аватар</button>
-            <span class="profile-section__avatar-hint">JPG, PNG или BMP. Макс. 2 МБ. Соотношение сторон аватара должно быть 1 к 1.</span>
+            <span class="profile-section__avatar-hint">JPG, PNG или BMP. Макс. 2 МБ. Аватар будет автоматически обрезан до квадрата.</span>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Парный PR к go-park-mail-ru/2026_1_KISS#41
- Удалена клиентская проверка `img.width !== img.height` при загрузке аватара
- Обновлен текст подсказки: "Аватар будет автоматически обрезан до квадрата"
- Бэкенд теперь автоматически кропит неквадратные изображения через smartcrop

## Test plan
- [ ] Загрузить неквадратное изображение → нет ошибки, аватар корректно отображается
- [ ] Загрузить квадратное изображение → работает как раньше
- [ ] Подсказка отображает новый текст