### PR TITLE
Hotfix: кнопка Создать блокнот ведет на регистрацию, а не вход

### DIFF
--- a/src/pages/landing/LandingPage.js
+++ b/src/pages/landing/LandingPage.js
@@ -33,18 +33,15 @@ export class LandingPage {
         if (!el) return;
 
         el.querySelector('[data-action="register"]')?.addEventListener('click', () => {
-            sessionStorage.setItem('registerPageState', JSON.stringify({ activeView: 'register' }));
-            Router.getInstance().navigate('/sign');
+            Router.getInstance().navigate('/sign?mode=register');
         });
 
         el.querySelector('[data-action="login"]')?.addEventListener('click', () => {
-            sessionStorage.setItem('registerPageState', JSON.stringify({ activeView: 'login' }));
-            Router.getInstance().navigate('/sign');
+            Router.getInstance().navigate('/sign?mode=login');
         });
 
         el.querySelector('[data-action="create-notebook"]')?.addEventListener('click', () => {
-            sessionStorage.setItem('registerPageState', JSON.stringify({ activeView: 'register' }));
-            Router.getInstance().navigate('/sign');
+            Router.getInstance().navigate('/sign?mode=register');
         });
     }
 

--- a/src/pages/sign/RegisterPage.js
+++ b/src/pages/sign/RegisterPage.js
@@ -142,6 +142,10 @@ export class RegisterPage {
      * @returns {Login|Register} форма для отображения
      */
     #restoreState() {
+        const urlMode = new URLSearchParams(window.location.search).get('mode');
+        if (urlMode === LOGIN_STATE) return this.#login;
+        if (urlMode === REGISTER_STATE) return this.#register;
+
         const savedState = sessionStorage.getItem(SESSION_ACTIVE_STATE);
         if (savedState) {
             try {

--- a/src/shared/router/Router.js
+++ b/src/shared/router/Router.js
@@ -112,7 +112,8 @@ export class Router {
      * @param {string} path -- текущий pathname
      */
     #handleRoute(path) {
-        const matched = this.#matchRoute(path);
+        const [pathname] = path.split('?');
+        const matched = this.#matchRoute(pathname);
         if (!matched) {
             this.navigate(this.#defaultPath);
             return;


### PR DESCRIPTION
## Summary
- Кнопка "Создать блокнот" на лендинге вела на форму входа вместо регистрации
- **Причина**: `sessionStorage` ненадежен -- если пользователь ранее нажимал "Войти", значение `login` перезаписывалось, но RegisterPage мог не считать новое
- **Фикс**: Кнопки лендинга теперь передают `?mode=register` / `?mode=login` через URL
- RegisterPage читает `?mode=` из URL с приоритетом над sessionStorage
- Router стрипает query string перед матчингом маршрутов

## Test plan
- [ ] Нажать "Создать блокнот" на лендинге -> форма регистрации
- [ ] Нажать "Войти" на лендинге -> форма входа
- [ ] Нажать "Регистрация" на лендинге -> форма регистрации
- [ ] Переключение форм на /sign по-прежнему работает