### PR TITLE
Унифицировать хедер и шрифты на лендинге с остальным приложением

### DIFF
--- a/src/pages/landing/LandingPage.css
+++ b/src/pages/landing/LandingPage.css
@@ -1,43 +1,7 @@
 .landing-page {
-    min-height: 100vh;
     display: flex;
     flex-direction: column;
-    background: var(--white);
-}
-
-.landing-page__header {
-    background-color: var(--teal-green);
-    color: var(--white);
-    padding: 10px 10px;
-    width: 100%;
-    box-sizing: border-box;
-}
-
-.landing-page__header-container {
-    margin: 0 auto;
-    padding: 0 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.landing-page__header-buttons {
-    display: flex;
-    gap: 1rem;
-}
-
-.landing-page__header-btn {
-    background: none;
-    border: none;
-    color: var(--white);
-    font-size: 14px;
-    font-family: inherit;
-    cursor: pointer;
-    padding: 6px 12px;
-}
-
-.landing-page__header-btn:hover {
-    text-decoration: underline;
+    flex: 1;
 }
 
 .landing-page__main {
@@ -58,7 +22,6 @@
     font-weight: 600;
     color: var(--teal-green);
     margin: 0 0 32px;
-    font-family: monospace;
 }
 
 .landing-page__quote {
@@ -70,7 +33,6 @@
     font-size: 16px;
     line-height: 1.6;
     color: var(--dark-primary);
-    font-family: monospace;
 }
 
 .landing-page__cta {
@@ -100,7 +62,6 @@
     font-weight: 400;
     color: var(--dark-primary);
     margin: 0 0 40px;
-    font-family: monospace;
 }
 
 .landing-page__features-grid {

--- a/src/pages/landing/LandingPage.js
+++ b/src/pages/landing/LandingPage.js
@@ -1,9 +1,11 @@
 import { LandingPageTemplate } from './LandingPage.template.js';
+import { GreenHeader } from '../../widgets/green-header/GreenHeader.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { Router } from '../../shared/router/Router.js';
 
 export class LandingPage {
     #root;
+    #header;
 
     constructor(root) {
         this.#root = root;
@@ -22,6 +24,19 @@ export class LandingPage {
             /* not logged in */
         }
 
+        this.#header = new GreenHeader(this.#root);
+        this.#header.render();
+
+        this.#header.registerBtn?.addEventListener('click', (e) => {
+            e.preventDefault();
+            Router.getInstance().navigate('/sign?mode=register');
+        });
+
+        this.#header.loginBtn?.addEventListener('click', (e) => {
+            e.preventDefault();
+            Router.getInstance().navigate('/sign?mode=login');
+        });
+
         const tempContainer = document.createElement('div');
         tempContainer.innerHTML = LandingPageTemplate();
         this.#root.appendChild(tempContainer.firstElementChild);
@@ -32,20 +47,13 @@ export class LandingPage {
         const el = this.#root.querySelector('.landing-page');
         if (!el) return;
 
-        el.querySelector('[data-action="register"]')?.addEventListener('click', () => {
-            Router.getInstance().navigate('/sign?mode=register');
-        });
-
-        el.querySelector('[data-action="login"]')?.addEventListener('click', () => {
-            Router.getInstance().navigate('/sign?mode=login');
-        });
-
         el.querySelector('[data-action="create-notebook"]')?.addEventListener('click', () => {
             Router.getInstance().navigate('/sign?mode=register');
         });
     }
 
     destroy() {
+        if (this.#header) this.#header.destroy();
         this.#root.innerHTML = '';
     }
 }

--- a/src/pages/landing/LandingPage.scss
+++ b/src/pages/landing/LandingPage.scss
@@ -1,43 +1,7 @@
 .landing-page {
-    min-height: 100vh;
     display: flex;
     flex-direction: column;
-    background: var(--white);
-}
-
-.landing-page__header {
-    background-color: var(--teal-green);
-    color: var(--white);
-    padding: 10px 10px;
-    width: 100%;
-    box-sizing: border-box;
-}
-
-.landing-page__header-container {
-    margin: 0 auto;
-    padding: 0 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.landing-page__header-buttons {
-    display: flex;
-    gap: 1rem;
-}
-
-.landing-page__header-btn {
-    background: none;
-    border: none;
-    color: var(--white);
-    font-size: 14px;
-    font-family: inherit;
-    cursor: pointer;
-    padding: 6px 12px;
-}
-
-.landing-page__header-btn:hover {
-    text-decoration: underline;
+    flex: 1;
 }
 
 .landing-page__main {
@@ -58,7 +22,6 @@
     font-weight: 600;
     color: var(--teal-green);
     margin: 0 0 32px;
-    font-family: monospace;
 }
 
 .landing-page__quote {
@@ -70,7 +33,6 @@
     font-size: 16px;
     line-height: 1.6;
     color: var(--dark-primary);
-    font-family: monospace;
 }
 
 .landing-page__cta {
@@ -100,7 +62,6 @@
     font-weight: 400;
     color: var(--dark-primary);
     margin: 0 0 40px;
-    font-family: monospace;
 }
 
 .landing-page__features-grid {

--- a/src/pages/landing/LandingPage.template.js
+++ b/src/pages/landing/LandingPage.template.js
@@ -1,17 +1,5 @@
 export function LandingPageTemplate() {
     return `<div class="landing-page">
-    <header class="landing-page__header">
-        <div class="landing-page__header-container">
-            <a href="/" class="logo-link">
-                <img src="/images/NewLogoTransparentWhite.svg" alt="KissColab" class="logo-image">
-            </a>
-            <div class="landing-page__header-buttons">
-                <button class="landing-page__header-btn" data-action="register">Регистрация</button>
-                <button class="landing-page__header-btn" data-action="login">Войти</button>
-            </div>
-        </div>
-    </header>
-
     <main class="landing-page__main">
         <section class="landing-page__hero">
             <h1 class="landing-page__title">Kisscolab: Простые блокноты для кода в один клик</h1>


### PR DESCRIPTION
## Summary
- Лендинг использовал собственный хедер с другими стилями кнопок и шрифтами (`monospace`), отличающимися от `/sign`
- **Фикс**: лендинг теперь переиспользует `GreenHeader` компонент -- те же кнопки `base-btn just-text`, тот же шрифт, тот же hover
- Убран `font-family: monospace` из стилей лендинга
- Удалены неиспользуемые стили хедера (`.landing-page__header-*`)
- Кнопки GreenHeader подключены к навигации `/sign?mode=register|login`

## Test plan
- [ ] Открыть `/` -- хедер идентичен хедеру на `/sign` (KissColab лого, кнопки Войти/Регистрация)
- [ ] Шрифт на лендинге совпадает с `/sign`
- [ ] Кнопки при hover показывают outline (как на `/sign`)
- [ ] "Регистрация" -> `/sign` (форма регистрации)
- [ ] "Войти" -> `/sign` (форма входа)