### PR TITLE
Hotfix: кнопка Создать блокнот ведет на вход, а не регистрацию

### DIFF
--- a/src/pages/landing/LandingPage.js
+++ b/src/pages/landing/LandingPage.js
@@ -48,7 +48,7 @@ export class LandingPage {
         if (!el) return;
 
         el.querySelector('[data-action="create-notebook"]')?.addEventListener('click', () => {
-            Router.getInstance().navigate('/sign?mode=register');
+            Router.getInstance().navigate('/sign?mode=login');
         });
     }
 


### PR DESCRIPTION
## Summary
- Кнопка "Создать блокнот" на лендинге вела на `/sign?mode=register` (регистрацию), а должна на `/sign?mode=login` (авторизацию)

## Test plan
- [ ] Нажать "Создать блокнот" на лендинге -> форма входа