### PR TITLE
ci(deploy): replace git pull with reset --hard origin/main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
             git fetch origin main
             CHANGED=$(git diff --name-only HEAD origin/main)
 
-            git pull origin main
+            git reset --hard origin/main
 
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
## Summary
- Fixes the failing deploy run: `git pull origin main` aborted with `Need to specify how to reconcile divergent branches` because the on-server checkout had a stale `develop` branch with one local commit while `origin/main` advanced independently.
- Switches the on-server step from `git pull` to `git reset --hard origin/main`, mirroring the strategy already used by the Go backend deploy. The production checkout is single-source-of-truth from `origin/main`; any local commits there are unintended and should be discarded on each deploy.

## Server state already synced
The server checkout (`/home/ubuntu/front/2026_1_KISS`) was manually moved to `main` and reset to `origin/main` (`36ed35f`) so the next deploy starts from a clean state. No local commits were lost — the only divergent local commit (`2c85ce3 fixing notebook page toolbar`) is already present on `origin/main` as `20f325e`.

## Followups (out of scope for this PR)
- `nvm` is **not installed** at `\$HOME/.nvm` on the production server, so the `[ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"` line in this workflow silently no-ops and `npm ci`/`npm run build` end up using the system Node 18.19.1 instead of the 22.21.0 declared in `.nvmrc`. A separate change is needed (install nvm + the pinned Node, or move the build into the GitHub Actions runner and ship `dist/` via `scp`).

## Test plan
- [ ] Push a small change to `main` and confirm the Deploy workflow completes the SSH step (no divergent-branches abort).
- [ ] Verify the SSH log shows `HEAD is now at <sha>` matching the PR commit.
- [ ] Confirm `colkiss.ru` serves the new build.