### PR TITLE
fix(ui): make main compile under strict TypeScript + add typecheck to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,6 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run lint
       - run: npm run format:check

--- a/src/feedback/FeedbackPage.ts
+++ b/src/feedback/FeedbackPage.ts
@@ -226,7 +226,7 @@ export class FeedbackPage {
         submitBtn.textContent = 'Отправка...';
 
         try {
-            await this.#issueApi.createIssue(this.#selectedCategory, content);
+            await this.#issueApi.createIssue(nn(this.#selectedCategory), content);
             this.#renderSuccess();
         } catch (e: unknown) {
             errorEl.textContent = (e as Error).message || 'Не удалось отправить обращение';
@@ -349,7 +349,9 @@ export class FeedbackPage {
                     </div>
                     <div class="feedback-modal__issue-preview">${this.#esc(preview)}</div>`;
 
-                const deleteBtn = nn(card.querySelector('.feedback-modal__issue-delete-btn'));
+                const deleteBtn = nn(
+                    card.querySelector<HTMLButtonElement>('.feedback-modal__issue-delete-btn')
+                );
                 // eslint-disable-next-line @typescript-eslint/no-misused-promises
                 deleteBtn.addEventListener('click', async (e: Event) => {
                     e.stopPropagation();

--- a/src/pages/profile/ProfilePage.ts
+++ b/src/pages/profile/ProfilePage.ts
@@ -106,7 +106,7 @@ export class ProfilePage {
                 nn(Router.getInstance()).navigate('/sign');
             }
         };
-        if (nn(this.#user).is_admin !== undefined && is_admin !== null) {
+        if (nn(this.#user).is_admin !== undefined && nn(this.#user).is_admin !== null) {
             headerConfig.onAdmin = (): void => {
                 nn(Router.getInstance()).navigate('/admin');
             };

--- a/src/shared/api/NotebookWS.ts
+++ b/src/shared/api/NotebookWS.ts
@@ -125,7 +125,7 @@ export class NotebookWS {
      * @returns true если WebSocket в состоянии OPEN
      */
     public isOpen(): boolean {
-        return Boolean(this.#socket) && this.#socket.readyState === WebSocket.OPEN;
+        return this.#socket !== null && this.#socket.readyState === WebSocket.OPEN;
     }
 
     /**

--- a/src/shared/components/code-cell/CodeCell.ts
+++ b/src/shared/components/code-cell/CodeCell.ts
@@ -327,7 +327,8 @@ export class CodeCell extends BaseComponent {
 
         (el as HTMLElement).hidden = !hasAny;
 
-        const stdoutText = (out.stdout?.length ?? 0) !== 0 ? out.stdout.join('\n') : '';
+        const stdoutText =
+            out.stdout !== undefined && out.stdout.length > 0 ? out.stdout.join('\n') : '';
         stdoutEl.innerHTML = stdoutText ? ansiToHtml(handleCarriageReturns(stdoutText)) : '';
 
         const stderrText = [out.stderr?.join('\n') ?? '', out.error ?? '']

--- a/src/shared/components/input/Input.ts
+++ b/src/shared/components/input/Input.ts
@@ -187,7 +187,7 @@ export class Input extends BaseComponent {
             errorMessage = 'Это поле обязательно';
         }
 
-        if (isValid && Boolean(this.#config.pattern)) {
+        if (isValid && this.#config.pattern !== null) {
             const regex = new RegExp(this.#config.pattern);
             if (!regex.test(this.#state.value)) {
                 isValid = false;
@@ -197,7 +197,7 @@ export class Input extends BaseComponent {
 
         if (
             isValid &&
-            Boolean(this.#config.minlength) &&
+            this.#config.minlength !== null &&
             this.#state.value.length < this.#config.minlength
         ) {
             isValid = false;
@@ -206,7 +206,7 @@ export class Input extends BaseComponent {
 
         if (
             isValid &&
-            Boolean(this.#config.maxlength) &&
+            this.#config.maxlength !== null &&
             this.#state.value.length > this.#config.maxlength
         ) {
             isValid = false;

--- a/src/shared/heartbeat/Heartbeat.ts
+++ b/src/shared/heartbeat/Heartbeat.ts
@@ -55,7 +55,7 @@ export class Heartbeat {
      * logout'е чтобы прекратить трекинг.
      */
     public stop(): void {
-        if ((this.#intervalId ?? 0) !== 0) {
+        if (this.#intervalId !== null) {
             clearInterval(this.#intervalId);
             this.#intervalId = null;
         }

--- a/src/widgets/admin-stats-section/AdminStatsSection.ts
+++ b/src/widgets/admin-stats-section/AdminStatsSection.ts
@@ -201,11 +201,11 @@ export class AdminStatsSection {
      * @param keyField - имя поля с ключом X (date/month/label)
      * @param valueField - имя поля с числовым значением Y
      */
-    #renderTimeSeriesChart(
+    #renderTimeSeriesChart<T extends object>(
         titleText: string,
-        data: Record<string, unknown>[],
-        keyField: string,
-        valueField: string
+        data: T[],
+        keyField: keyof T & string,
+        valueField: keyof T & string
     ): void {
         const chart = document.createElement('div');
         chart.className = 'admin-chart';

--- a/src/widgets/filter-bar/FilterBar.ts
+++ b/src/widgets/filter-bar/FilterBar.ts
@@ -288,9 +288,9 @@ export class FilterBar extends BaseComponent {
         dateBtn.classList.remove('filter-bar__dropdown-btn_active');
         dateBtn.textContent = 'Изменено';
 
-        nn(this._element.querySelector('.filter-bar__date-from')).value = '';
-        nn(this._element.querySelector('.filter-bar__date-to')).value = '';
-        nn(this._element.querySelector('.filter-bar__search-input')).value = '';
+        nn(this._element.querySelector<HTMLInputElement>('.filter-bar__date-from')).value = '';
+        nn(this._element.querySelector<HTMLInputElement>('.filter-bar__date-to')).value = '';
+        nn(this._element.querySelector<HTMLInputElement>('.filter-bar__search-input')).value = '';
 
         clearTimeout(nn(this.#searchDebounce));
         this.#onFilterChange({ owner: null, dateFrom: null, dateTo: null, search: '' });

--- a/src/widgets/notebook-sidebar/NotebookSidebar.ts
+++ b/src/widgets/notebook-sidebar/NotebookSidebar.ts
@@ -364,7 +364,7 @@ export class NotebookSidebar extends BaseComponent {
      * Останавливает поллинг container stats.
      */
     #stopContainerPolling(): void {
-        if ((this.#containerPollTimer ?? 0) !== 0) {
+        if (this.#containerPollTimer !== null) {
             clearInterval(this.#containerPollTimer);
             this.#containerPollTimer = null;
         }

--- a/src/widgets/password-section/PasswordSection.ts
+++ b/src/widgets/password-section/PasswordSection.ts
@@ -120,7 +120,7 @@ export class PasswordSection extends BaseComponent {
 
                 if (!response.ok) {
                     const result = (await response.json()) as { error?: string };
-                    msgEl.textContent = translateError(result.error);
+                    msgEl.textContent = translateError(result.error ?? '');
                     msgEl.classList.add('password-section__msg--error');
                     return;
                 }

--- a/src/widgets/profile-section/ProfileSection.ts
+++ b/src/widgets/profile-section/ProfileSection.ts
@@ -149,7 +149,7 @@ export class ProfileSection extends BaseComponent {
                     const result = (await response.json()) as Partial<ApiEnvelope<UserDTO>>;
 
                     if (!response.ok) {
-                        errorEl.textContent = translateError(result.error);
+                        errorEl.textContent = translateError(result.error ?? '');
                         return;
                     }
 
@@ -218,7 +218,7 @@ export class ProfileSection extends BaseComponent {
                 const result = (await response.json()) as Partial<ApiEnvelope<UserDTO>>;
 
                 if (!response.ok) {
-                    msgEl.textContent = translateError(result.error);
+                    msgEl.textContent = translateError(result.error ?? '');
                     msgEl.classList.add('profile-section__save-msg--error');
                     return;
                 }
@@ -310,7 +310,7 @@ export class ProfileSection extends BaseComponent {
                 const result = (await response.json()) as Partial<ApiEnvelope<UserDTO>>;
 
                 if (!response.ok) {
-                    emailMsg.textContent = translateError(result.error);
+                    emailMsg.textContent = translateError(result.error ?? '');
                     emailMsg.style.color = 'var(--error-red)';
                     return;
                 }


### PR DESCRIPTION
## Why
Deploy is failing on the on-server `tsc` step because `main` does not compile. The build error lay dormant because `lint.yml` runs only ESLint + Prettier — not the type checker — so 23 real `tsc` errors slipped into `main`. The site has been serving an older `dist/` from a previous successful deploy, and only the next deploy attempt surfaced the problem.

Locally on Node 25.2.1 (newer than `.nvmrc`'s 22.21.0) the same errors reproduce, confirming this is a code/typing problem and not an engine issue.

## What
**Code fixes (12 files, 23 errors).** All minimal, no behavior changes:

| File | Change |
|---|---|
| `src/feedback/FeedbackPage.ts` | `nn()` guard for `selectedCategory`; `querySelector<HTMLButtonElement>` for delete button. |
| `src/pages/profile/ProfilePage.ts` | Typo in `is_admin` guard: bare `is_admin` → `nn(this.#user).is_admin`. |
| `src/shared/api/NotebookWS.ts` | `Boolean(this.#socket)` → `this.#socket !== null` so TS narrows the union. |
| `src/shared/components/code-cell/CodeCell.ts` | Explicit `out.stdout !== undefined` narrowing for `.join('\n')`. |
| `src/shared/components/input/Input.ts` | `Boolean(...)` gates → explicit `!== null` for `pattern`/`minlength`/`maxlength`. |
| `src/shared/heartbeat/Heartbeat.ts` | `(id ?? 0) !== 0` → `id !== null` so `clearInterval` gets `number`, not `number \| null`. |
| `src/widgets/notebook-sidebar/NotebookSidebar.ts` | Same pattern as Heartbeat for `#containerPollTimer`. |
| `src/widgets/admin-stats-section/AdminStatsSection.ts` | `#renderTimeSeriesChart` made generic `<T extends object>` so `DayPoint[]`/`MonthPoint[]` are accepted without forcing an index signature on the named interfaces. |
| `src/widgets/filter-bar/FilterBar.ts` | Typed `querySelector<HTMLInputElement>` on three lines. |
| `src/widgets/password-section/PasswordSection.ts` | `translateError(result.error)` → `translateError(result.error ?? '')` for the optional error field. |
| `src/widgets/profile-section/ProfileSection.ts` | Same `?? ''` fallback in three call sites. |

**CI hardening.** `lint.yml` now runs `npm run typecheck` before lint/format. The `typecheck` script (`tsc --noEmit`) already exists in `package.json` — it just wasn't wired into CI. This closes the gap that allowed these errors to merge.

## Local verification
On Node 25.2.1:
```
$ npm run typecheck   # clean
$ npm run lint         # clean (--max-warnings 0)
$ npm run format:check # clean
$ npm run build        # produces dist/app.js (449 kB), dist/feedback.js (36 kB), dist/app.css (83 kB)
```

## Style discipline
Per `CLAUDE.md` Rule #1, no edits to `eslint.config.mjs`, `.prettierrc.js`, `tsconfig.json`, or `package.json` scripts. No new comments outside of two short JSDoc descriptions on the new chart-helper generic. All fixes go through `nn()` / typed `querySelector` / explicit null guards as the project's existing style mandates.

## Test plan
- [ ] CI checks pass on this PR (now includes typecheck).
- [ ] After merge into `main`, Deploy workflow finishes the SSH `npm run build` step without `tsc` errors.
- [ ] `colkiss.ru` serves the freshly built bundle.

## Followup (still out of scope)
- Server still has no `nvm`, so `npm run build` runs on system Node 18.19.1 instead of 22.21.0. Today the build succeeds anyway, but this is a latent risk — separate ticket.