### PR TITLE
fix(infra): allow oauth avatar cdns in csp img-src

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -49,7 +49,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; style-src 'self' 'unsafe-inline' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; img-src 'self' data: blob: https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; connect-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; frame-src https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; font-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; style-src 'self' 'unsafe-inline' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; img-src 'self' data: blob: https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru https://*.googleusercontent.com https://*.userapi.com https://avatars.yandex.net; connect-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; frame-src https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; font-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru;" always;
 
     location /api/ {
         proxy_pass http://212.233.96.54:8080;
@@ -108,7 +108,7 @@ server {
         expires -1;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header X-Content-Type-Options "nosniff" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; style-src 'self' 'unsafe-inline' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; img-src 'self' data: blob: https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; connect-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; frame-src https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; font-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru;" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; style-src 'self' 'unsafe-inline' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; img-src 'self' data: blob: https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru https://*.googleusercontent.com https://*.userapi.com https://avatars.yandex.net; connect-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; frame-src https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru; font-src 'self' https://yookassa.ru https://*.yookassa.ru https://yoomoney.ru https://*.yoomoney.ru;" always;
     }
 
     location ~* \.(css|js|svg|png|jpg|jpeg|gif|ico|woff|woff2|ttf|eot|otf)$ {


### PR DESCRIPTION
## Summary

After oauth login worked end-to-end in production (Google/Yandex/VK ID all create users now), new users' avatars rendered as broken-image. Root cause: `Content-Security-Policy` `img-src` only whitelisted `'self'`, `data:`, `blob:`, and yookassa/yoomoney — none of the oauth provider CDNs:

| Provider | Avatar URL pattern |
|---|---|
| Google | `https://lh3.googleusercontent.com/a/...` |
| VK ID | `https://sun*.userapi.com/...` |
| Yandex | `https://avatars.yandex.net/get-yapic/...` |

Verified by querying the prod DB — `avatar_url` is populated for Google (user 1041) and VK (user 1043) but the `<img>` is blocked by CSP. Added three wildcards to `img-src` in both `location /` and `location /api/`.
