### PR TITLE
feat: страница «Диск» с drag-and-drop, квотой и админкой файлов

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -18,6 +18,9 @@
 @use '../widgets/green-header/GreenHeader';
 @use '../widgets/filter-bar/FilterBar';
 @use '../widgets/files-table/FilesTable';
+@use '../widgets/file-drop-zone/FileDropZone';
+@use '../widgets/disk-table/DiskTable';
+@use '../widgets/disk-usage-card/DiskUsageCard';
 @use '../widgets/share-modal/ShareModal';
 @use '../widgets/notebook-header/NotebookHeader';
 @use '../widgets/notebook-toolbar/NotebookToolbar';
@@ -30,9 +33,11 @@
 @use '../widgets/feedback-modal/FeedbackModal';
 @use '../widgets/stats-section/StatsSection';
 @use '../widgets/container-stats/ContainerStats';
+@use '../widgets/admin-files-section/AdminFilesSection';
 
 @use '../pages/sign/RegisterPage';
 @use '../pages/files/FilesPage';
+@use '../pages/disk/DiskPage';
 @use '../pages/blocks/BlocksPage';
 @use '../pages/profile/ProfilePage';
 @use '../pages/landing/LandingPage';

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -22,6 +22,9 @@
 @use '../widgets/disk-table/DiskTable';
 @use '../widgets/disk-usage-card/DiskUsageCard';
 @use '../widgets/share-modal/ShareModal';
+@use '../widgets/file-share-modal/FileShareModal';
+@use '../widgets/rename-modal/RenameModal';
+@use '../pages/shared-file/SharedFilePage';
 @use '../widgets/notebook-header/NotebookHeader';
 @use '../widgets/notebook-toolbar/NotebookToolbar';
 @use '../widgets/notebook-sidebar/NotebookSidebar';

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,6 +1,7 @@
 import { LandingPage } from '../pages/landing/LandingPage.js';
 import { RegisterPage } from '../pages/sign/RegisterPage.js';
 import { FilesPage } from '../pages/files/FilesPage.js';
+import { DiskPage } from '../pages/disk/DiskPage.js';
 import { BlocksPage } from '../pages/blocks/BlocksPage.js';
 import { ProfilePage } from '../pages/profile/ProfilePage.js';
 import { AdminPage } from '../pages/admin/AdminPage.js';
@@ -18,6 +19,7 @@ router.addRoute('/sign', RegisterPage, { guard: 'guestOnly' });
 router.addRoute('/login', RegisterPage, { guard: 'guestOnly' });
 router.addRoute('/register', RegisterPage, { guard: 'guestOnly' });
 router.addRoute('/files', FilesPage, { guard: 'authOnly' });
+router.addRoute('/disk', DiskPage, { guard: 'authOnly' });
 router.addRoute('/notebooks/:id', BlocksPage, { guard: 'authOnly' });
 router.addRoute('/profile', ProfilePage, { guard: 'authOnly' });
 router.addRoute('/admin', AdminPage, { guard: 'authOnly' });

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -5,6 +5,7 @@ import { DiskPage } from '../pages/disk/DiskPage.js';
 import { BlocksPage } from '../pages/blocks/BlocksPage.js';
 import { ProfilePage } from '../pages/profile/ProfilePage.js';
 import { AdminPage } from '../pages/admin/AdminPage.js';
+import { SharedFilePage } from '../pages/shared-file/SharedFilePage.js';
 import { Router } from '../shared/router/Router.js';
 import { HttpClient } from '../shared/http_client/HttpClient.js';
 import { Heartbeat } from '../shared/heartbeat/Heartbeat.js';
@@ -23,6 +24,7 @@ router.addRoute('/disk', DiskPage, { guard: 'authOnly' });
 router.addRoute('/notebooks/:id', BlocksPage, { guard: 'authOnly' });
 router.addRoute('/profile', ProfilePage, { guard: 'authOnly' });
 router.addRoute('/admin', AdminPage, { guard: 'authOnly' });
+router.addRoute('/shared/files/:token', SharedFilePage);
 
 /**
  * Опрашивает /auth/me и обновляет snapshot авторизации внутри HttpClient.

--- a/src/pages/admin/AdminPage.ts
+++ b/src/pages/admin/AdminPage.ts
@@ -4,6 +4,7 @@ import { AdminStatsSection } from '../../widgets/admin-stats-section/AdminStatsS
 import { AdminNotebooksSection } from '../../widgets/admin-notebooks-section/AdminNotebooksSection.js';
 import { AdminIssuesSection } from '../../widgets/admin-issues-section/AdminIssuesSection.js';
 import { AdminUsersSection } from '../../widgets/admin-users-section/AdminUsersSection.js';
+import { AdminFilesSection } from '../../widgets/admin-files-section/AdminFilesSection.js';
 import { Router } from '../../shared/router/Router.js';
 import { FeedbackModal } from '../../widgets/feedback-modal/FeedbackModal.js';
 import { nn } from '../../shared/utils/notNull.js';
@@ -28,6 +29,7 @@ function AdminPageTemplate(): string {
                 <button class="admin-page__sidebar-item" data-section="users">Пользователи</button>
                 <button class="admin-page__sidebar-item" data-section="notebooks">Блокноты</button>
                 <button class="admin-page__sidebar-item" data-section="issues">Обращения</button>
+                <button class="admin-page__sidebar-item" data-section="files">Файлы</button>
             </div>
         </nav>
         <div class="admin-page__content"></div>
@@ -190,6 +192,11 @@ export class AdminPage {
             }
             case 'issues': {
                 const section = new AdminIssuesSection(nn(this.#contentArea));
+                section.mount();
+                break;
+            }
+            case 'files': {
+                const section = new AdminFilesSection(nn(this.#contentArea));
                 section.mount();
                 break;
             }

--- a/src/pages/disk/DiskPage.scss
+++ b/src/pages/disk/DiskPage.scss
@@ -1,0 +1,25 @@
+.disk-page {
+    min-height: 100vh;
+    background: #f3f7f3;
+}
+
+.disk-page__main {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 24px 16px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.disk-page__title-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.disk-page__title {
+    margin: 0;
+    font-size: 22px;
+    color: #1e2a1f;
+}

--- a/src/pages/disk/DiskPage.scss
+++ b/src/pages/disk/DiskPage.scss
@@ -23,3 +23,37 @@
     font-size: 22px;
     color: #1e2a1f;
 }
+
+.disk-page__tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid #e6efe7;
+    margin-top: 4px;
+}
+
+.disk-page__tab {
+    padding: 8px 14px;
+    border: none;
+    background: transparent;
+    color: #5a6a5c;
+    font-size: 14px;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+}
+
+.disk-page__tab:hover {
+    color: #2e7233;
+}
+
+.disk-page__tab_active {
+    color: #2e7233;
+    border-bottom-color: #2e7233;
+    font-weight: 600;
+}
+
+.disk-page__panel {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}

--- a/src/pages/disk/DiskPage.scss
+++ b/src/pages/disk/DiskPage.scss
@@ -24,36 +24,3 @@
     color: #1e2a1f;
 }
 
-.disk-page__tabs {
-    display: flex;
-    gap: 4px;
-    border-bottom: 1px solid #e6efe7;
-    margin-top: 4px;
-}
-
-.disk-page__tab {
-    padding: 8px 14px;
-    border: none;
-    background: transparent;
-    color: #5a6a5c;
-    font-size: 14px;
-    cursor: pointer;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
-}
-
-.disk-page__tab:hover {
-    color: #2e7233;
-}
-
-.disk-page__tab_active {
-    color: #2e7233;
-    border-bottom-color: #2e7233;
-    font-weight: 600;
-}
-
-.disk-page__panel {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}

--- a/src/pages/disk/DiskPage.template.ts
+++ b/src/pages/disk/DiskPage.template.ts
@@ -1,6 +1,6 @@
 /**
  * Шаблон страницы «Диск»: контейнер для шапки, карточки квоты, drop-зоны,
- * таблицы файлов и пагинации. Реальные виджеты монтируются в DiskPage.render.
+ * табов (мои файлы / расшарено со мной), таблицы файлов и пагинации.
  * @returns HTML-разметка для innerHTML
  */
 export function DiskPageTemplate(): string {
@@ -11,9 +11,19 @@ export function DiskPageTemplate(): string {
             <h1 class="disk-page__title">Мой диск</h1>
         </div>
         <div class="disk-page__usage-mount"></div>
-        <div class="disk-page__drop-mount"></div>
-        <div class="disk-page__table-mount"></div>
-        <div class="disk-page__pagination-mount"></div>
+        <div class="disk-page__tabs">
+            <button type="button" class="disk-page__tab disk-page__tab_active" data-tab="own">Мои файлы</button>
+            <button type="button" class="disk-page__tab" data-tab="shared">Расшарено со мной</button>
+        </div>
+        <div class="disk-page__panel disk-page__panel_own">
+            <div class="disk-page__drop-mount"></div>
+            <div class="disk-page__table-mount"></div>
+            <div class="disk-page__pagination-mount"></div>
+        </div>
+        <div class="disk-page__panel disk-page__panel_shared" hidden>
+            <div class="disk-page__shared-table-mount"></div>
+            <div class="disk-page__shared-pagination-mount"></div>
+        </div>
     </main>
 </div>`;
 }

--- a/src/pages/disk/DiskPage.template.ts
+++ b/src/pages/disk/DiskPage.template.ts
@@ -1,0 +1,19 @@
+/**
+ * Шаблон страницы «Диск»: контейнер для шапки, карточки квоты, drop-зоны,
+ * таблицы файлов и пагинации. Реальные виджеты монтируются в DiskPage.render.
+ * @returns HTML-разметка для innerHTML
+ */
+export function DiskPageTemplate(): string {
+    return `<div class="disk-page">
+    <div class="disk-page__header-mount"></div>
+    <main class="disk-page__main">
+        <div class="disk-page__title-row">
+            <h1 class="disk-page__title">Мой диск</h1>
+        </div>
+        <div class="disk-page__usage-mount"></div>
+        <div class="disk-page__drop-mount"></div>
+        <div class="disk-page__table-mount"></div>
+        <div class="disk-page__pagination-mount"></div>
+    </main>
+</div>`;
+}

--- a/src/pages/disk/DiskPage.template.ts
+++ b/src/pages/disk/DiskPage.template.ts
@@ -1,6 +1,6 @@
 /**
- * Шаблон страницы «Диск»: контейнер для шапки, карточки квоты, drop-зоны,
- * табов (мои файлы / расшарено со мной), таблицы файлов и пагинации.
+ * Шаблон страницы «Диск»: контейнер для шапки, карточки квоты, drop-зоны
+ * и единой таблицы файлов (свои + расшаренные со мной).
  * @returns HTML-разметка для innerHTML
  */
 export function DiskPageTemplate(): string {
@@ -11,19 +11,8 @@ export function DiskPageTemplate(): string {
             <h1 class="disk-page__title">Мой диск</h1>
         </div>
         <div class="disk-page__usage-mount"></div>
-        <div class="disk-page__tabs">
-            <button type="button" class="disk-page__tab disk-page__tab_active" data-tab="own">Мои файлы</button>
-            <button type="button" class="disk-page__tab" data-tab="shared">Расшарено со мной</button>
-        </div>
-        <div class="disk-page__panel disk-page__panel_own">
-            <div class="disk-page__drop-mount"></div>
-            <div class="disk-page__table-mount"></div>
-            <div class="disk-page__pagination-mount"></div>
-        </div>
-        <div class="disk-page__panel disk-page__panel_shared" hidden>
-            <div class="disk-page__shared-table-mount"></div>
-            <div class="disk-page__shared-pagination-mount"></div>
-        </div>
+        <div class="disk-page__drop-mount"></div>
+        <div class="disk-page__table-mount"></div>
     </main>
 </div>`;
 }

--- a/src/pages/disk/DiskPage.ts
+++ b/src/pages/disk/DiskPage.ts
@@ -2,6 +2,8 @@ import { GreenHeader } from '../../widgets/green-header/GreenHeader.js';
 import { FileDropZone } from '../../widgets/file-drop-zone/FileDropZone.js';
 import { DiskTable } from '../../widgets/disk-table/DiskTable.js';
 import { DiskUsageCard } from '../../widgets/disk-usage-card/DiskUsageCard.js';
+import { FileShareModal } from '../../widgets/file-share-modal/FileShareModal.js';
+import { RenameModal } from '../../widgets/rename-modal/RenameModal.js';
 import { Pagination } from '../../shared/components/pagination/Pagination.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { StorageApi } from '../../shared/api/StorageApi.js';
@@ -19,12 +21,10 @@ import { DiskPageTemplate } from './DiskPage.template.js';
 const PAGE_SIZE = 10;
 
 /**
- * Страница «Мой диск» (`/disk`). Показывает заполненность квоты, зону
- * drag-and-drop для загрузки, таблицу файлов пользователя и пагинацию.
- * Авторизованным пользователям; неавторизованных редиректит на /sign.
- *
- * Загрузка/удаление обновляют usage-card и таблицу. Дублирование запросов
- * минимально: после mutation делаем ровно один list + один usage.
+ * Страница «Мой диск» (`/disk`). Содержит две вкладки: «Мои файлы»
+ * (с drag-and-drop, квотой, действиями владельца) и «Расшарено со мной»
+ * (файлы от других пользователей). Авторизованным пользователям;
+ * неавторизованных редиректит на /sign.
  */
 export class DiskPage {
     #root: HTMLElement;
@@ -34,10 +34,15 @@ export class DiskPage {
     #usageCard: DiskUsageCard | null = null;
     #dropZone: FileDropZone | null = null;
     #table: DiskTable | null = null;
+    #sharedTable: DiskTable | null = null;
     #pagination: Pagination | null = null;
+    #sharedPagination: Pagination | null = null;
     #feedbackModal: FeedbackModal | null = null;
     #currentPage = 0;
     #totalPages = 1;
+    #sharedPage = 0;
+    #sharedTotalPages = 1;
+    #activeTab: 'own' | 'shared' = 'own';
 
     /**
      * Сохраняет root и берёт singleton-клиенты.
@@ -50,8 +55,8 @@ export class DiskPage {
     }
 
     /**
-     * Загружает текущего пользователя, монтирует шапку и все виджеты,
-     * подгружает первую страницу файлов и квоту. При недоступности бэка —
+     * Загружает текущего пользователя, монтирует шапку и виджеты обеих вкладок,
+     * подгружает первую страницу собственных файлов. При недоступности бэка —
      * показывает «server unavailable». При 401 — редирект на /sign.
      */
     public async render(): Promise<void> {
@@ -77,14 +82,13 @@ export class DiskPage {
 
         this.#root.innerHTML = DiskPageTemplate();
         this.#mountWidgets(user);
+        this.#attachTabSwitching();
         await this.#loadList();
     }
 
     /**
-     * Создаёт и монтирует все виджеты страницы: шапку, карточку квоты,
-     * drop-зону, таблицу файлов и пагинацию. Выделено отдельно, чтобы
-     * render() не превышал лимит max-statements.
-     * @param user - данные текущего пользователя для шапки
+     * Создаёт и монтирует все виджеты страницы.
+     * @param user - данные текущего пользователя
      */
     #mountWidgets(user: UserDTO): void {
         const root = this.#root;
@@ -93,6 +97,12 @@ export class DiskPage {
         const dropMount = nn(root.querySelector<HTMLElement>('.disk-page__drop-mount'));
         const tableMount = nn(root.querySelector<HTMLElement>('.disk-page__table-mount'));
         const paginationMount = nn(root.querySelector<HTMLElement>('.disk-page__pagination-mount'));
+        const sharedTableMount = nn(
+            root.querySelector<HTMLElement>('.disk-page__shared-table-mount')
+        );
+        const sharedPaginationMount = nn(
+            root.querySelector<HTMLElement>('.disk-page__shared-pagination-mount')
+        );
 
         this.#header = new GreenHeader(headerMount, this.#buildHeaderConfig(user));
         this.#header.render();
@@ -106,8 +116,15 @@ export class DiskPage {
         this.#dropZone.mount();
 
         this.#table = new DiskTable(tableMount, {
+            mode: 'own',
             onDelete: (file): void => {
                 void this.#handleDelete(file);
+            },
+            onShare: (file): void => {
+                void this.#handleShare(file);
+            },
+            onRename: (file): void => {
+                this.#handleRename(file);
             }
         });
         this.#table.mount();
@@ -117,11 +134,59 @@ export class DiskPage {
             void this.#loadList();
         });
         this.#pagination.mount();
+
+        this.#sharedTable = new DiskTable(sharedTableMount, {
+            mode: 'shared',
+            onDelete: (): void => {
+                /* нельзя удалять чужие */
+            }
+        });
+        this.#sharedTable.mount();
+
+        this.#sharedPagination = new Pagination(sharedPaginationMount, (page) => {
+            this.#sharedPage = page;
+            void this.#loadSharedList();
+        });
+        this.#sharedPagination.mount();
     }
 
     /**
-     * Собирает конфиг для GreenHeader из текущего пользователя: callbacks
-     * на навигацию, открытие фидбека и logout.
+     * Навешивает обработчики переключения вкладок.
+     */
+    #attachTabSwitching(): void {
+        const tabs = this.#root.querySelectorAll<HTMLButtonElement>('.disk-page__tab');
+        tabs.forEach((tab) => {
+            tab.addEventListener('click', () => {
+                const target = tab.dataset.tab === 'shared' ? 'shared' : 'own';
+                void this.#switchTab(target);
+            });
+        });
+    }
+
+    /**
+     * Переключает активную вкладку, обновляя визуальное состояние и подгружая
+     * данные. Вызов идемпотентен — повторное переключение на ту же вкладку
+     * ничего не делает.
+     * @param next - новая активная вкладка
+     */
+    async #switchTab(next: 'own' | 'shared'): Promise<void> {
+        if (next === this.#activeTab) return;
+        this.#activeTab = next;
+        const tabs = this.#root.querySelectorAll<HTMLButtonElement>('.disk-page__tab');
+        tabs.forEach((t) => {
+            t.classList.toggle('disk-page__tab_active', t.dataset.tab === next);
+        });
+        const ownPanel = nn(this.#root.querySelector<HTMLElement>('.disk-page__panel_own'));
+        const sharedPanel = nn(this.#root.querySelector<HTMLElement>('.disk-page__panel_shared'));
+        ownPanel.hidden = next !== 'own';
+        sharedPanel.hidden = next !== 'shared';
+        if (next === 'shared') {
+            await this.#loadSharedList();
+        }
+    }
+
+    /**
+     * Собирает конфиг для GreenHeader из текущего пользователя.
      * @param user - данные пользователя из /auth/me
      * @returns объект конфигурации для GreenHeader
      */
@@ -158,26 +223,27 @@ export class DiskPage {
     }
 
     /**
-     * Размонтирует все виджеты и очищает root. Вызывается роутером перед сменой
-     * страницы.
+     * Размонтирует все виджеты и очищает root.
      */
     public destroy(): void {
         this.#header?.destroy();
         this.#usageCard?.unmount();
         this.#dropZone?.unmount();
         this.#table?.unmount();
+        this.#sharedTable?.unmount();
         this.#pagination?.unmount();
+        this.#sharedPagination?.unmount();
         this.#header = null;
         this.#usageCard = null;
         this.#dropZone = null;
         this.#table = null;
+        this.#sharedTable = null;
         this.#pagination = null;
+        this.#sharedPagination = null;
     }
 
     /**
-     * Подгружает текущую страницу файлов и обновляет таблицу и пагинацию.
-     * Ошибки отображает через статус drop-zone (на странице больше нет
-     * выделенной области для ошибок листинга).
+     * Подгружает текущую страницу собственных файлов.
      */
     async #loadList(): Promise<void> {
         try {
@@ -193,10 +259,23 @@ export class DiskPage {
     }
 
     /**
-     * Последовательно загружает файлы один за другим (HttpClient.upload не
-     * умеет параллельный прогресс, а сервер делает квота-проверку — поэтому
-     * последовательность даёт стабильное сообщение об ошибке). После каждой
-     * загрузки рефрешит квоту; в конце — рефреш списка.
+     * Подгружает текущую страницу файлов, расшаренных текущему пользователю.
+     */
+    async #loadSharedList(): Promise<void> {
+        try {
+            const offset = this.#sharedPage * PAGE_SIZE;
+            const resp = await this.#storage.listSharedWithMe(PAGE_SIZE, offset);
+            this.#sharedTotalPages = Math.max(1, Math.ceil(resp.total / PAGE_SIZE));
+            this.#sharedTable?.setData(resp.files);
+            this.#sharedPagination?.update(this.#sharedPage, this.#sharedTotalPages);
+        } catch (error: unknown) {
+            logError('DiskPage.loadSharedList failed', error);
+        }
+    }
+
+    /**
+     * Последовательно загружает выбранные файлы; .ipynb разруливает в импорт
+     * нотебука.
      * @param files - выбранные/перетянутые файлы
      */
     async #handleUpload(files: File[]): Promise<void> {
@@ -231,10 +310,7 @@ export class DiskPage {
     }
 
     /**
-     * Импортирует .ipynb-файл как новый ноутбук вместо обычной загрузки в
-     * хранилище: парсит JSON, превращает ячейки в блоки, отправляет на
-     * /notebooks/import и редиректит на страницу созданного ноутбука.
-     * Имя ноутбука берётся из имени файла без расширения.
+     * Импортирует .ipynb-файл как новый ноутбук.
      * @param file - выбранный пользователем .ipynb-файл
      */
     async #handleIpynbImport(file: File): Promise<void> {
@@ -256,8 +332,7 @@ export class DiskPage {
 
     /**
      * Спрашивает подтверждение и удаляет файл, после чего обновляет таблицу
-     * и квоту. confirm используется как простой UX-механизм; для продакшна
-     * можно завести модалку.
+     * и квоту.
      * @param file - файл к удалению
      */
     async #handleDelete(file: FileItemDTO): Promise<void> {
@@ -272,5 +347,25 @@ export class DiskPage {
             logError('DiskPage.handleDelete failed', error);
             this.#dropZone?.setStatus('Не удалось удалить файл', 'error');
         }
+    }
+
+    /**
+     * Открывает модалку шаринга для файла. После закрытия — обновляет список
+     * (на случай, если поменялась публичность или счётчики).
+     * @param file - файл для шаринга
+     */
+    async #handleShare(file: FileItemDTO): Promise<void> {
+        await FileShareModal.getInstance().open(file);
+        await this.#loadList();
+    }
+
+    /**
+     * Открывает модалку переименования; после сохранения — обновляет список.
+     * @param file - файл к переименованию
+     */
+    #handleRename(file: FileItemDTO): void {
+        RenameModal.getInstance().open(file, () => {
+            void this.#loadList();
+        });
     }
 }

--- a/src/pages/disk/DiskPage.ts
+++ b/src/pages/disk/DiskPage.ts
@@ -4,7 +4,6 @@ import { DiskTable } from '../../widgets/disk-table/DiskTable.js';
 import { DiskUsageCard } from '../../widgets/disk-usage-card/DiskUsageCard.js';
 import { FileShareModal } from '../../widgets/file-share-modal/FileShareModal.js';
 import { RenameModal } from '../../widgets/rename-modal/RenameModal.js';
-import { Pagination } from '../../shared/components/pagination/Pagination.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { StorageApi } from '../../shared/api/StorageApi.js';
 import { NotebookApi } from '../../shared/api/NotebookApi.js';
@@ -18,31 +17,24 @@ import { renderServerUnavailable } from '../../shared/utils/serverUnavailable.js
 import type { ApiEnvelope, FileItemDTO, UserDTO } from '../../shared/api/types.js';
 import { DiskPageTemplate } from './DiskPage.template.js';
 
-const PAGE_SIZE = 10;
+const MAX_FILES_PER_SOURCE = 100;
 
 /**
- * Страница «Мой диск» (`/disk`). Содержит две вкладки: «Мои файлы»
- * (с drag-and-drop, квотой, действиями владельца) и «Расшарено со мной»
- * (файлы от других пользователей). Авторизованным пользователям;
- * неавторизованных редиректит на /sign.
+ * Страница «Мой диск» (`/disk`): объединённая таблица собственных файлов
+ * и файлов, расшаренных текущему пользователю, отсортированная по дате.
+ * Доступ через `your_permission`: 'owner' для своих, 'view' / 'download'
+ * для расшаренных. Действия — через контекстное меню в таблице.
  */
 export class DiskPage {
     #root: HTMLElement;
     #httpClient: HttpClient;
     #storage: StorageApi;
+    #user: UserDTO | null = null;
     #header: GreenHeader | null = null;
     #usageCard: DiskUsageCard | null = null;
     #dropZone: FileDropZone | null = null;
     #table: DiskTable | null = null;
-    #sharedTable: DiskTable | null = null;
-    #pagination: Pagination | null = null;
-    #sharedPagination: Pagination | null = null;
     #feedbackModal: FeedbackModal | null = null;
-    #currentPage = 0;
-    #totalPages = 1;
-    #sharedPage = 0;
-    #sharedTotalPages = 1;
-    #activeTab: 'own' | 'shared' = 'own';
 
     /**
      * Сохраняет root и берёт singleton-клиенты.
@@ -55,9 +47,8 @@ export class DiskPage {
     }
 
     /**
-     * Загружает текущего пользователя, монтирует шапку и виджеты обеих вкладок,
-     * подгружает первую страницу собственных файлов. При недоступности бэка —
-     * показывает «server unavailable». При 401 — редирект на /sign.
+     * Загружает текущего пользователя, монтирует виджеты и подгружает
+     * объединённый список файлов. При 401 — редирект на /sign.
      */
     public async render(): Promise<void> {
         this.#root.innerHTML = '';
@@ -80,10 +71,10 @@ export class DiskPage {
             return;
         }
 
+        this.#user = user;
         this.#root.innerHTML = DiskPageTemplate();
         this.#mountWidgets(user);
-        this.#attachTabSwitching();
-        await this.#loadList();
+        await this.#loadAll();
     }
 
     /**
@@ -96,13 +87,6 @@ export class DiskPage {
         const usageMount = nn(root.querySelector<HTMLElement>('.disk-page__usage-mount'));
         const dropMount = nn(root.querySelector<HTMLElement>('.disk-page__drop-mount'));
         const tableMount = nn(root.querySelector<HTMLElement>('.disk-page__table-mount'));
-        const paginationMount = nn(root.querySelector<HTMLElement>('.disk-page__pagination-mount'));
-        const sharedTableMount = nn(
-            root.querySelector<HTMLElement>('.disk-page__shared-table-mount')
-        );
-        const sharedPaginationMount = nn(
-            root.querySelector<HTMLElement>('.disk-page__shared-pagination-mount')
-        );
 
         this.#header = new GreenHeader(headerMount, this.#buildHeaderConfig(user));
         this.#header.render();
@@ -116,7 +100,6 @@ export class DiskPage {
         this.#dropZone.mount();
 
         this.#table = new DiskTable(tableMount, {
-            mode: 'own',
             onDelete: (file): void => {
                 void this.#handleDelete(file);
             },
@@ -128,67 +111,12 @@ export class DiskPage {
             }
         });
         this.#table.mount();
-
-        this.#pagination = new Pagination(paginationMount, (page) => {
-            this.#currentPage = page;
-            void this.#loadList();
-        });
-        this.#pagination.mount();
-
-        this.#sharedTable = new DiskTable(sharedTableMount, {
-            mode: 'shared',
-            onDelete: (): void => {
-                /* нельзя удалять чужие */
-            }
-        });
-        this.#sharedTable.mount();
-
-        this.#sharedPagination = new Pagination(sharedPaginationMount, (page) => {
-            this.#sharedPage = page;
-            void this.#loadSharedList();
-        });
-        this.#sharedPagination.mount();
     }
 
     /**
-     * Навешивает обработчики переключения вкладок.
-     */
-    #attachTabSwitching(): void {
-        const tabs = this.#root.querySelectorAll<HTMLButtonElement>('.disk-page__tab');
-        tabs.forEach((tab) => {
-            tab.addEventListener('click', () => {
-                const target = tab.dataset.tab === 'shared' ? 'shared' : 'own';
-                void this.#switchTab(target);
-            });
-        });
-    }
-
-    /**
-     * Переключает активную вкладку, обновляя визуальное состояние и подгружая
-     * данные. Вызов идемпотентен — повторное переключение на ту же вкладку
-     * ничего не делает.
-     * @param next - новая активная вкладка
-     */
-    async #switchTab(next: 'own' | 'shared'): Promise<void> {
-        if (next === this.#activeTab) return;
-        this.#activeTab = next;
-        const tabs = this.#root.querySelectorAll<HTMLButtonElement>('.disk-page__tab');
-        tabs.forEach((t) => {
-            t.classList.toggle('disk-page__tab_active', t.dataset.tab === next);
-        });
-        const ownPanel = nn(this.#root.querySelector<HTMLElement>('.disk-page__panel_own'));
-        const sharedPanel = nn(this.#root.querySelector<HTMLElement>('.disk-page__panel_shared'));
-        ownPanel.hidden = next !== 'own';
-        sharedPanel.hidden = next !== 'shared';
-        if (next === 'shared') {
-            await this.#loadSharedList();
-        }
-    }
-
-    /**
-     * Собирает конфиг для GreenHeader из текущего пользователя.
-     * @param user - данные пользователя из /auth/me
-     * @returns объект конфигурации для GreenHeader
+     * Собирает конфиг для GreenHeader.
+     * @param user - данные пользователя
+     * @returns объект конфигурации
      */
     #buildHeaderConfig(user: UserDTO): Record<string, unknown> {
         const initials = user.username.substring(0, 2).toUpperCase();
@@ -230,52 +158,53 @@ export class DiskPage {
         this.#usageCard?.unmount();
         this.#dropZone?.unmount();
         this.#table?.unmount();
-        this.#sharedTable?.unmount();
-        this.#pagination?.unmount();
-        this.#sharedPagination?.unmount();
         this.#header = null;
         this.#usageCard = null;
         this.#dropZone = null;
         this.#table = null;
-        this.#sharedTable = null;
-        this.#pagination = null;
-        this.#sharedPagination = null;
     }
 
     /**
-     * Подгружает текущую страницу собственных файлов.
+     * Параллельно подгружает собственные и расшаренные файлы, объединяет
+     * в один список, помечает «свои» признаком your_permission='owner' и
+     * сортирует по дате. Ошибки одной из сторон отображает через статус
+     * drop-zone, но не блокирует отображение другой.
      */
-    async #loadList(): Promise<void> {
-        try {
-            const offset = this.#currentPage * PAGE_SIZE;
-            const resp = await this.#storage.listFiles(PAGE_SIZE, offset, 'files');
-            this.#totalPages = Math.max(1, Math.ceil(resp.total / PAGE_SIZE));
-            this.#table?.setData(resp.files);
-            this.#pagination?.update(this.#currentPage, this.#totalPages);
-        } catch (error: unknown) {
-            logError('DiskPage.loadList failed', error);
+    async #loadAll(): Promise<void> {
+        const ownerEmail = this.#user?.email ?? '';
+        const [ownResult, sharedResult] = await Promise.allSettled([
+            this.#storage.listFiles(MAX_FILES_PER_SOURCE, 0, 'files'),
+            this.#storage.listSharedWithMe(MAX_FILES_PER_SOURCE, 0)
+        ]);
+        const files: FileItemDTO[] = [];
+        if (ownResult.status === 'fulfilled') {
+            for (const f of ownResult.value.files) {
+                files.push({
+                    ...f,
+                    your_permission: 'owner',
+                    owner_email:
+                        f.owner_email !== undefined && f.owner_email !== ''
+                            ? f.owner_email
+                            : ownerEmail
+                });
+            }
+        } else {
+            logError('DiskPage.loadAll: own files failed', ownResult.reason);
             this.#dropZone?.setStatus('Не удалось загрузить список файлов', 'error');
         }
-    }
-
-    /**
-     * Подгружает текущую страницу файлов, расшаренных текущему пользователю.
-     */
-    async #loadSharedList(): Promise<void> {
-        try {
-            const offset = this.#sharedPage * PAGE_SIZE;
-            const resp = await this.#storage.listSharedWithMe(PAGE_SIZE, offset);
-            this.#sharedTotalPages = Math.max(1, Math.ceil(resp.total / PAGE_SIZE));
-            this.#sharedTable?.setData(resp.files);
-            this.#sharedPagination?.update(this.#sharedPage, this.#sharedTotalPages);
-        } catch (error: unknown) {
-            logError('DiskPage.loadSharedList failed', error);
+        if (sharedResult.status === 'fulfilled') {
+            for (const f of sharedResult.value.files) {
+                files.push(f);
+            }
+        } else {
+            logError('DiskPage.loadAll: shared files failed', sharedResult.reason);
         }
+        files.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+        this.#table?.setData(files);
     }
 
     /**
-     * Последовательно загружает выбранные файлы; .ipynb разруливает в импорт
-     * нотебука.
+     * Последовательно загружает выбранные файлы; .ipynb уходят в импорт ноутбука.
      * @param files - выбранные/перетянутые файлы
      */
     async #handleUpload(files: File[]): Promise<void> {
@@ -306,12 +235,12 @@ export class DiskPage {
             const detail = failed.map((f) => `${f.name}: ${f.message}`).join('; ');
             this.#dropZone?.setStatus(`Загружено ${String(okCount)}, ошибки: ${detail}`, 'error');
         }
-        await this.#loadList();
+        await this.#loadAll();
     }
 
     /**
      * Импортирует .ipynb-файл как новый ноутбук.
-     * @param file - выбранный пользователем .ipynb-файл
+     * @param file - выбранный .ipynb
      */
     async #handleIpynbImport(file: File): Promise<void> {
         this.#dropZone?.setStatus(`Импорт ноутбука "${file.name}"...`, 'info');
@@ -342,7 +271,7 @@ export class DiskPage {
         try {
             await this.#storage.deleteFile(file.id);
             await this.#usageCard?.refresh();
-            await this.#loadList();
+            await this.#loadAll();
         } catch (error: unknown) {
             logError('DiskPage.handleDelete failed', error);
             this.#dropZone?.setStatus('Не удалось удалить файл', 'error');
@@ -350,22 +279,21 @@ export class DiskPage {
     }
 
     /**
-     * Открывает модалку шаринга для файла. После закрытия — обновляет список
-     * (на случай, если поменялась публичность или счётчики).
+     * Открывает модалку шаринга. После закрытия обновляет список.
      * @param file - файл для шаринга
      */
     async #handleShare(file: FileItemDTO): Promise<void> {
         await FileShareModal.getInstance().open(file);
-        await this.#loadList();
+        await this.#loadAll();
     }
 
     /**
-     * Открывает модалку переименования; после сохранения — обновляет список.
+     * Открывает модалку переименования. После сохранения обновляет список.
      * @param file - файл к переименованию
      */
     #handleRename(file: FileItemDTO): void {
         RenameModal.getInstance().open(file, () => {
-            void this.#loadList();
+            void this.#loadAll();
         });
     }
 }

--- a/src/pages/disk/DiskPage.ts
+++ b/src/pages/disk/DiskPage.ts
@@ -5,6 +5,8 @@ import { DiskUsageCard } from '../../widgets/disk-usage-card/DiskUsageCard.js';
 import { Pagination } from '../../shared/components/pagination/Pagination.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { StorageApi } from '../../shared/api/StorageApi.js';
+import { NotebookApi } from '../../shared/api/NotebookApi.js';
+import { ipynbToBlocks } from '../../shared/domain/notebook/nbformat.js';
 import { Router } from '../../shared/router/Router.js';
 import { FeedbackModal } from '../../widgets/feedback-modal/FeedbackModal.js';
 import { nn } from '../../shared/utils/notNull.js';
@@ -199,6 +201,13 @@ export class DiskPage {
      */
     async #handleUpload(files: File[]): Promise<void> {
         if (files.length === 0) return;
+
+        const ipynb = files.find((f) => f.name.toLowerCase().endsWith('.ipynb'));
+        if (ipynb) {
+            await this.#handleIpynbImport(ipynb);
+            return;
+        }
+
         this.#dropZone?.setStatus(`Загрузка ${String(files.length)} ...`, 'info');
         let okCount = 0;
         const failed: { name: string; message: string }[] = [];
@@ -219,6 +228,30 @@ export class DiskPage {
             this.#dropZone?.setStatus(`Загружено ${String(okCount)}, ошибки: ${detail}`, 'error');
         }
         await this.#loadList();
+    }
+
+    /**
+     * Импортирует .ipynb-файл как новый ноутбук вместо обычной загрузки в
+     * хранилище: парсит JSON, превращает ячейки в блоки, отправляет на
+     * /notebooks/import и редиректит на страницу созданного ноутбука.
+     * Имя ноутбука берётся из имени файла без расширения.
+     * @param file - выбранный пользователем .ipynb-файл
+     */
+    async #handleIpynbImport(file: File): Promise<void> {
+        this.#dropZone?.setStatus(`Импорт ноутбука "${file.name}"...`, 'info');
+        try {
+            const text = await file.text();
+            const parsed = JSON.parse(text) as { cells?: Record<string, unknown>[] };
+            const blocks = ipynbToBlocks(parsed);
+            const title = file.name.replace(/\.ipynb$/i, '') || 'Импортированный ноутбук';
+            const notebook = await new NotebookApi().importNotebook(title, blocks);
+            this.#dropZone?.setStatus(`Ноутбук "${title}" импортирован`, 'ok');
+            nn(Router.getInstance()).navigate(`/notebooks/${String(notebook.id)}`);
+        } catch (error: unknown) {
+            logError('DiskPage.handleIpynbImport failed', error);
+            const msg = error instanceof Error ? error.message : 'неизвестная ошибка';
+            this.#dropZone?.setStatus(`Не удалось импортировать ноутбук: ${msg}`, 'error');
+        }
     }
 
     /**

--- a/src/pages/disk/DiskPage.ts
+++ b/src/pages/disk/DiskPage.ts
@@ -1,0 +1,243 @@
+import { GreenHeader } from '../../widgets/green-header/GreenHeader.js';
+import { FileDropZone } from '../../widgets/file-drop-zone/FileDropZone.js';
+import { DiskTable } from '../../widgets/disk-table/DiskTable.js';
+import { DiskUsageCard } from '../../widgets/disk-usage-card/DiskUsageCard.js';
+import { Pagination } from '../../shared/components/pagination/Pagination.js';
+import { HttpClient } from '../../shared/http_client/HttpClient.js';
+import { StorageApi } from '../../shared/api/StorageApi.js';
+import { Router } from '../../shared/router/Router.js';
+import { FeedbackModal } from '../../widgets/feedback-modal/FeedbackModal.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { logError } from '../../shared/utils/logger.js';
+import { isAuthError } from '../../shared/http_client/authStatus.js';
+import { renderServerUnavailable } from '../../shared/utils/serverUnavailable.js';
+import type { ApiEnvelope, FileItemDTO, UserDTO } from '../../shared/api/types.js';
+import { DiskPageTemplate } from './DiskPage.template.js';
+
+const PAGE_SIZE = 10;
+
+/**
+ * Страница «Мой диск» (`/disk`). Показывает заполненность квоты, зону
+ * drag-and-drop для загрузки, таблицу файлов пользователя и пагинацию.
+ * Авторизованным пользователям; неавторизованных редиректит на /sign.
+ *
+ * Загрузка/удаление обновляют usage-card и таблицу. Дублирование запросов
+ * минимально: после mutation делаем ровно один list + один usage.
+ */
+export class DiskPage {
+    #root: HTMLElement;
+    #httpClient: HttpClient;
+    #storage: StorageApi;
+    #header: GreenHeader | null = null;
+    #usageCard: DiskUsageCard | null = null;
+    #dropZone: FileDropZone | null = null;
+    #table: DiskTable | null = null;
+    #pagination: Pagination | null = null;
+    #feedbackModal: FeedbackModal | null = null;
+    #currentPage = 0;
+    #totalPages = 1;
+
+    /**
+     * Сохраняет root и берёт singleton-клиенты.
+     * @param root - корневой элемент SPA
+     */
+    public constructor(root: HTMLElement) {
+        this.#root = root;
+        this.#httpClient = HttpClient.getInstance();
+        this.#storage = StorageApi.getInstance();
+    }
+
+    /**
+     * Загружает текущего пользователя, монтирует шапку и все виджеты,
+     * подгружает первую страницу файлов и квоту. При недоступности бэка —
+     * показывает «server unavailable». При 401 — редирект на /sign.
+     */
+    public async render(): Promise<void> {
+        this.#root.innerHTML = '';
+
+        let user: UserDTO;
+        try {
+            const response = await this.#httpClient.get('/auth/me');
+            if (isAuthError(response.status)) {
+                nn(Router.getInstance()).navigate('/sign');
+                return;
+            }
+            if (!response.ok) {
+                renderServerUnavailable(this.#root);
+                return;
+            }
+            const body = (await response.json()) as ApiEnvelope<UserDTO>;
+            user = body.data;
+        } catch (_e) {
+            renderServerUnavailable(this.#root);
+            return;
+        }
+
+        this.#root.innerHTML = DiskPageTemplate();
+        this.#mountWidgets(user);
+        await this.#loadList();
+    }
+
+    /**
+     * Создаёт и монтирует все виджеты страницы: шапку, карточку квоты,
+     * drop-зону, таблицу файлов и пагинацию. Выделено отдельно, чтобы
+     * render() не превышал лимит max-statements.
+     * @param user - данные текущего пользователя для шапки
+     */
+    #mountWidgets(user: UserDTO): void {
+        const root = this.#root;
+        const headerMount = nn(root.querySelector<HTMLElement>('.disk-page__header-mount'));
+        const usageMount = nn(root.querySelector<HTMLElement>('.disk-page__usage-mount'));
+        const dropMount = nn(root.querySelector<HTMLElement>('.disk-page__drop-mount'));
+        const tableMount = nn(root.querySelector<HTMLElement>('.disk-page__table-mount'));
+        const paginationMount = nn(root.querySelector<HTMLElement>('.disk-page__pagination-mount'));
+
+        this.#header = new GreenHeader(headerMount, this.#buildHeaderConfig(user));
+        this.#header.render();
+
+        this.#usageCard = new DiskUsageCard(usageMount);
+        this.#usageCard.mount();
+
+        this.#dropZone = new FileDropZone(dropMount, {
+            onFiles: (files): Promise<void> => this.#handleUpload(files)
+        });
+        this.#dropZone.mount();
+
+        this.#table = new DiskTable(tableMount, {
+            onDelete: (file): void => {
+                void this.#handleDelete(file);
+            }
+        });
+        this.#table.mount();
+
+        this.#pagination = new Pagination(paginationMount, (page) => {
+            this.#currentPage = page;
+            void this.#loadList();
+        });
+        this.#pagination.mount();
+    }
+
+    /**
+     * Собирает конфиг для GreenHeader из текущего пользователя: callbacks
+     * на навигацию, открытие фидбека и logout.
+     * @param user - данные пользователя из /auth/me
+     * @returns объект конфигурации для GreenHeader
+     */
+    #buildHeaderConfig(user: UserDTO): Record<string, unknown> {
+        const initials = user.username.substring(0, 2).toUpperCase();
+        const headerConfig: Record<string, unknown> = {
+            user: { username: user.username, initials, avatarUrl: user.avatar_url },
+            onProfile: (): void => {
+                nn(Router.getInstance()).navigate('/profile');
+            },
+            onFeedback: (): void => {
+                this.#feedbackModal ??= new FeedbackModal();
+                this.#feedbackModal.open();
+            },
+            onLogout: async (): Promise<void> => {
+                try {
+                    const response = await this.#httpClient.post('/auth/logout');
+                    if (response.ok || isAuthError(response.status)) {
+                        nn(Router.getInstance()).navigate('/sign');
+                        return;
+                    }
+                    logError('Logout failed with HTTP status', response.status);
+                } catch (e: unknown) {
+                    logError('Logout request failed', e);
+                }
+            }
+        };
+        if (user.is_admin) {
+            headerConfig.onAdmin = (): void => {
+                nn(Router.getInstance()).navigate('/admin');
+            };
+        }
+        return headerConfig;
+    }
+
+    /**
+     * Размонтирует все виджеты и очищает root. Вызывается роутером перед сменой
+     * страницы.
+     */
+    public destroy(): void {
+        this.#header?.destroy();
+        this.#usageCard?.unmount();
+        this.#dropZone?.unmount();
+        this.#table?.unmount();
+        this.#pagination?.unmount();
+        this.#header = null;
+        this.#usageCard = null;
+        this.#dropZone = null;
+        this.#table = null;
+        this.#pagination = null;
+    }
+
+    /**
+     * Подгружает текущую страницу файлов и обновляет таблицу и пагинацию.
+     * Ошибки отображает через статус drop-zone (на странице больше нет
+     * выделенной области для ошибок листинга).
+     */
+    async #loadList(): Promise<void> {
+        try {
+            const offset = this.#currentPage * PAGE_SIZE;
+            const resp = await this.#storage.listFiles(PAGE_SIZE, offset, 'files');
+            this.#totalPages = Math.max(1, Math.ceil(resp.total / PAGE_SIZE));
+            this.#table?.setData(resp.files);
+            this.#pagination?.update(this.#currentPage, this.#totalPages);
+        } catch (error: unknown) {
+            logError('DiskPage.loadList failed', error);
+            this.#dropZone?.setStatus('Не удалось загрузить список файлов', 'error');
+        }
+    }
+
+    /**
+     * Последовательно загружает файлы один за другим (HttpClient.upload не
+     * умеет параллельный прогресс, а сервер делает квота-проверку — поэтому
+     * последовательность даёт стабильное сообщение об ошибке). После каждой
+     * загрузки рефрешит квоту; в конце — рефреш списка.
+     * @param files - выбранные/перетянутые файлы
+     */
+    async #handleUpload(files: File[]): Promise<void> {
+        if (files.length === 0) return;
+        this.#dropZone?.setStatus(`Загрузка ${String(files.length)} ...`, 'info');
+        let okCount = 0;
+        const failed: { name: string; message: string }[] = [];
+        for (const file of files) {
+            try {
+                await this.#storage.uploadFile(file);
+                okCount += 1;
+                await this.#usageCard?.refresh();
+            } catch (error: unknown) {
+                const msg = error instanceof Error ? error.message : 'неизвестная ошибка';
+                failed.push({ name: file.name, message: msg });
+            }
+        }
+        if (failed.length === 0) {
+            this.#dropZone?.setStatus(`Загружено: ${String(okCount)}`, 'ok');
+        } else {
+            const detail = failed.map((f) => `${f.name}: ${f.message}`).join('; ');
+            this.#dropZone?.setStatus(`Загружено ${String(okCount)}, ошибки: ${detail}`, 'error');
+        }
+        await this.#loadList();
+    }
+
+    /**
+     * Спрашивает подтверждение и удаляет файл, после чего обновляет таблицу
+     * и квоту. confirm используется как простой UX-механизм; для продакшна
+     * можно завести модалку.
+     * @param file - файл к удалению
+     */
+    async #handleDelete(file: FileItemDTO): Promise<void> {
+        // eslint-disable-next-line no-alert -- TODO(ui): replace with confirmation modal
+        const ok = window.confirm(`Удалить "${file.filename}"?`);
+        if (!ok) return;
+        try {
+            await this.#storage.deleteFile(file.id);
+            await this.#usageCard?.refresh();
+            await this.#loadList();
+        } catch (error: unknown) {
+            logError('DiskPage.handleDelete failed', error);
+            this.#dropZone?.setStatus('Не удалось удалить файл', 'error');
+        }
+    }
+}

--- a/src/pages/files/FilesPage.ts
+++ b/src/pages/files/FilesPage.ts
@@ -1,6 +1,7 @@
 import { GreenHeader } from '../../widgets/green-header/GreenHeader.js';
 import { FilterBar } from '../../widgets/filter-bar/FilterBar.js';
 import { FilesTable } from '../../widgets/files-table/FilesTable.js';
+import { DiskUsageCard } from '../../widgets/disk-usage-card/DiskUsageCard.js';
 import { Pagination } from '../../shared/components/pagination/Pagination.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { Router } from '../../shared/router/Router.js';
@@ -43,6 +44,7 @@ export class FilesPage {
     #header: GreenHeader | null = null;
     #filterBar: FilterBar | null = null;
     #filesTable: FilesTable | null = null;
+    #diskUsageCard: DiskUsageCard | null = null;
     #pagination: Pagination | null = null;
     #allNotebooks: FilesNotebook[] = [];
     #filters: {
@@ -148,6 +150,13 @@ export class FilesPage {
         container.className = 'files-page__container';
         main.appendChild(container);
 
+        this.#diskUsageCard = new DiskUsageCard(container, {
+            onClick: (): void => {
+                nn(Router.getInstance()).navigate('/disk');
+            }
+        });
+        this.#diskUsageCard.mount();
+
         this.#filterBar = new FilterBar(container, {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onCreate: (): Promise<void> => this.#createNotebook(),
@@ -182,6 +191,7 @@ export class FilesPage {
      * Размонтирует все три виджета и очищает root. Вызывается роутером.
      */
     public destroy(): void {
+        if (this.#diskUsageCard) this.#diskUsageCard.unmount();
         if (this.#filterBar) this.#filterBar.unmount();
         if (this.#filesTable) this.#filesTable.unmount();
         if (this.#pagination) this.#pagination.unmount();

--- a/src/pages/files/FilesPage.ts
+++ b/src/pages/files/FilesPage.ts
@@ -151,6 +151,7 @@ export class FilesPage {
         main.appendChild(container);
 
         this.#diskUsageCard = new DiskUsageCard(container, {
+            compact: true,
             onClick: (): void => {
                 nn(Router.getInstance()).navigate('/disk');
             }

--- a/src/pages/shared-file/SharedFilePage.scss
+++ b/src/pages/shared-file/SharedFilePage.scss
@@ -1,0 +1,88 @@
+.shared-file-page {
+    min-height: 100vh;
+    background: #f8fbf8;
+    display: flex;
+    flex-direction: column;
+}
+
+.shared-file-page__header {
+    padding: 16px 24px;
+    border-bottom: 1px solid #e6efe7;
+    background: #fff;
+}
+
+.shared-file-page__brand {
+    color: #2e7233;
+    font-weight: 700;
+    text-decoration: none;
+    font-size: 18px;
+}
+
+.shared-file-page__main {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px 16px;
+}
+
+.shared-file-page__card {
+    width: 100%;
+    max-width: 420px;
+    background: #fff;
+    border: 1px solid #e6efe7;
+    border-radius: 12px;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.04);
+    padding: 32px 24px;
+    text-align: center;
+}
+
+.shared-file-page__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.shared-file-page__status {
+    color: #5a6a5c;
+    margin: 0;
+}
+
+.shared-file-page__file-icon {
+    color: #2e7233;
+}
+
+.shared-file-page__filename {
+    margin: 0;
+    font-size: 18px;
+    color: #2e3a2f;
+    word-break: break-all;
+}
+
+.shared-file-page__meta {
+    margin: 0;
+    color: #5a6a5c;
+    font-size: 13px;
+}
+
+.shared-file-page__download {
+    margin-top: 8px;
+    display: inline-block;
+    padding: 10px 18px;
+    background: #2e7233;
+    color: #fff;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.shared-file-page__download:hover {
+    background: #245a28;
+}
+
+.shared-file-page__error {
+    color: #b03a2e;
+    margin: 0;
+    font-size: 14px;
+}

--- a/src/pages/shared-file/SharedFilePage.template.ts
+++ b/src/pages/shared-file/SharedFilePage.template.ts
@@ -1,0 +1,46 @@
+import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+
+/**
+ * Рендерит каркас публичной страницы скачивания. Реальный контент (имя, размер,
+ * кнопка) вставляется JS-кодом после fetch'a /api/v1/shared/files/:token.
+ * @returns HTML-разметка для innerHTML
+ */
+export function SharedFilePageTemplate(): string {
+    return `<div class="shared-file-page">
+    <header class="shared-file-page__header">
+        <a class="shared-file-page__brand" href="/">KISS Colab</a>
+    </header>
+    <main class="shared-file-page__main">
+        <div class="shared-file-page__card">
+            <div class="shared-file-page__content">
+                <p class="shared-file-page__status">Загрузка…</p>
+            </div>
+        </div>
+    </main>
+</div>`;
+}
+
+/**
+ * Рендерит содержимое успешной карточки файла.
+ * @param filename - имя файла
+ * @param size - размер в байтах (отформатировано)
+ * @param mime - MIME-тип
+ * @param downloadHref - ссылка на скачивание (proxy для download endpoint)
+ * @returns HTML-разметка карточки
+ */
+export function SharedFileCard(
+    filename: string,
+    size: string,
+    mime: string,
+    downloadHref: string
+): string {
+    return `<div class="shared-file-page__file-icon">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
+            <polyline points="13 2 13 9 20 9"/>
+        </svg>
+    </div>
+    <h2 class="shared-file-page__filename">${escapeHtml(filename)}</h2>
+    <p class="shared-file-page__meta">${escapeHtml(size)} · ${escapeHtml(mime)}</p>
+    <a class="shared-file-page__download" href="${escapeHtml(downloadHref)}" download>Скачать</a>`;
+}

--- a/src/pages/shared-file/SharedFilePage.ts
+++ b/src/pages/shared-file/SharedFilePage.ts
@@ -1,0 +1,132 @@
+import { nn } from '../../shared/utils/notNull.js';
+import { formatBytes } from '../../shared/utils/formatBytes.js';
+import { logError } from '../../shared/utils/logger.js';
+import { SharedFileCard, SharedFilePageTemplate } from './SharedFilePage.template.js';
+
+/**
+ * Публичная страница `/shared/files/:token`: метаданные файла + кнопка
+ * «Скачать». Доступна без авторизации. Метаданные берутся из заголовков
+ * HEAD-запроса к `/api/v1/shared/files/:token` (бэк возвращает Content-
+ * Disposition с filename, Content-Length и Content-Type). По клику на
+ * «Скачать» происходит обычный GET того же endpoint'а, который инкрементит
+ * счётчик скачиваний.
+ */
+export class SharedFilePage {
+    #root: HTMLElement;
+
+    /**
+     * Сохраняет корневой элемент SPA для последующего рендеринга страницы.
+     * @param root - корневой DOM-узел
+     */
+    public constructor(root: HTMLElement) {
+        this.#root = root;
+    }
+
+    /**
+     * Рендерит страницу: вычисляет токен из URL, делает HEAD, заполняет
+     * карточку или показывает ошибку.
+     * @param params - параметры маршрута (ожидается :token)
+     */
+    public async render(params?: Record<string, string>): Promise<void> {
+        this.#root.innerHTML = SharedFilePageTemplate();
+        const token = params?.token ?? this.#extractTokenFromPath();
+        if (!token) {
+            this.#showError('Ссылка некорректна');
+            return;
+        }
+        await this.#fetchAndRender(token);
+    }
+
+    /**
+     * Размонтирует страницу со страницы (вызывается роутером при смене маршрута).
+     */
+    public destroy(): void {
+        this.#root.innerHTML = '';
+    }
+
+    /**
+     * Берёт токен из текущего pathname вида /shared/files/<token>.
+     * @returns токен или пустую строку
+     */
+    #extractTokenFromPath(): string {
+        const parts = window.location.pathname.split('/').filter(Boolean);
+        return parts[parts.length - 1] ?? '';
+    }
+
+    /**
+     * HEAD на download endpoint. Если 410 — ссылка истекла, 404 — не найдено.
+     * На успехе достаёт имя/размер/MIME из заголовков и строит карточку.
+     * @param token - share-токен из URL
+     */
+    async #fetchAndRender(token: string): Promise<void> {
+        const url = `/api/v1/shared/files/${encodeURIComponent(token)}`;
+        try {
+            const head = await fetch(url, { method: 'HEAD' });
+            if (head.status === 410) {
+                this.#showError('Срок действия ссылки истёк');
+                return;
+            }
+            if (head.status === 404) {
+                this.#showError('Файл не найден');
+                return;
+            }
+            if (!head.ok) {
+                this.#showError('Не удалось загрузить файл');
+                return;
+            }
+            const filename = this.#extractFilename(head.headers.get('content-disposition'));
+            const sizeStr = formatBytes(Number(head.headers.get('content-length') ?? 0));
+            const mime = head.headers.get('content-type') ?? 'application/octet-stream';
+            this.#renderCard(filename, sizeStr, mime, url);
+        } catch (error) {
+            logError('SharedFilePage.fetch failed', error);
+            this.#showError('Сервер недоступен');
+        }
+    }
+
+    /**
+     * Достаёт имя файла из заголовка Content-Disposition.
+     * @param header - значение заголовка или null
+     * @returns имя файла либо «Файл»
+     */
+    #extractFilename(header: string | null): string {
+        if (header === null || header === '') return 'Файл';
+        const m = /filename\*?="?([^";]+)"?/u.exec(header);
+        if (m?.[1] === undefined) return 'Файл';
+        return m[1].trim();
+    }
+
+    /**
+     * Подменяет содержимое карточки на успешный шаблон.
+     * @param filename - имя файла
+     * @param size - размер (отформатированный)
+     * @param mime - MIME
+     * @param href - download URL
+     */
+    #renderCard(filename: string, size: string, mime: string, href: string): void {
+        const content = nn(this.#root.querySelector<HTMLElement>('.shared-file-page__content'));
+        content.innerHTML = SharedFileCard(filename, size, mime, href);
+    }
+
+    /**
+     * Подменяет содержимое карточки на сообщение об ошибке.
+     * @param message - текст для отображения
+     */
+    #showError(message: string): void {
+        const content = nn(this.#root.querySelector<HTMLElement>('.shared-file-page__content'));
+        content.innerHTML = `<p class="shared-file-page__error">${this.#escape(message)}</p>`;
+    }
+
+    /**
+     * Экранирует HTML-спецсимволы для безопасной вставки.
+     * @param str - исходная строка
+     * @returns строка без HTML-инъекций
+     */
+    #escape(str: string): string {
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+}

--- a/src/shared/api/StorageApi.ts
+++ b/src/shared/api/StorageApi.ts
@@ -1,0 +1,145 @@
+import { HttpClient } from '../http_client/HttpClient.js';
+import type { ApiEnvelope, FileItemDTO, FileListResponse, FileUsageResponse } from './types.js';
+
+/**
+ * API-клиент storage-сервиса: загрузка пользовательских файлов, листинг,
+ * удаление, информация о занятой квоте. Бэкенд: cmd/storage (через gateway,
+ * /api/v1/files/*). Лимит на пользователя выставляется по тарифу на стороне
+ * gateway — клиент только читает результат /files/usage.
+ */
+export class StorageApi {
+    static #instance: StorageApi | null = null;
+
+    #http: HttpClient;
+
+    /**
+     * Прямой вызов запрещён — используйте getInstance(), чтобы все API-клиенты
+     * делили один HttpClient (и его кэш/сессию).
+     * @throws Error при попытке создать второй экземпляр
+     */
+    public constructor() {
+        if (StorageApi.#instance) {
+            throw new Error('Use StorageApi.getInstance() instead of new StorageApi()');
+        }
+        this.#http = HttpClient.getInstance();
+        StorageApi.#instance = this;
+    }
+
+    /**
+     * Возвращает singleton-экземпляр клиента, создавая при первом обращении.
+     * @returns единственный экземпляр StorageApi
+     */
+    public static getInstance(): StorageApi {
+        StorageApi.#instance ??= new StorageApi();
+        return StorageApi.#instance;
+    }
+
+    /**
+     * Парсит JSON-ответ с ApiEnvelope, бросает Error при не-2xx.
+     * @param response - объект Response от fetch
+     * @returns распакованный data типа T
+     * @throws Error со строкой error или 'HTTP <status>'
+     */
+    async #parse<T>(response: Response): Promise<T> {
+        const body = (await response.json().catch(() => ({}))) as Partial<ApiEnvelope<T>>;
+        if (!response.ok) {
+            throw new Error(body.error ?? `HTTP ${String(response.status)}`);
+        }
+        return body.data as T;
+    }
+
+    /**
+     * Загружает один файл в storage. Соответствует POST /api/v1/files/upload
+     * с multipart/form-data и query-параметром category. Сервер проверяет
+     * MIME, расширение и квоту тарифа; при превышении квоты вернёт 507.
+     * @param file - объект File из input[type=file] или drag-and-drop
+     * @param category - категория хранения ('files' по умолчанию)
+     * @returns промис с FileItemDTO загруженного файла
+     * @throws Error при HTTP не-2xx (например 507 при превышении квоты,
+     *   400 при недопустимом MIME/расширении)
+     */
+    public async uploadFile(file: File, category = 'files'): Promise<FileItemDTO> {
+        const url = `/files/upload?category=${encodeURIComponent(category)}`;
+        const response = await this.#http.upload(url, file, 'file');
+        return this.#parse<FileItemDTO>(response);
+    }
+
+    /**
+     * Загружает страницу файлов текущего пользователя. Соответствует
+     * GET /api/v1/files?category=&limit=&offset=. Категория опциональна:
+     * пустая строка вернёт файлы всех категорий.
+     * @param limit - размер страницы (макс 100 на бэке)
+     * @param offset - смещение страницы
+     * @param category - фильтр по категории (необязателен)
+     * @returns промис с FileListResponse (массив files + total)
+     * @throws Error при HTTP не-2xx
+     */
+    public async listFiles(
+        limit: number,
+        offset: number,
+        category?: string
+    ): Promise<FileListResponse> {
+        const params = new URLSearchParams();
+        params.set('limit', String(limit));
+        params.set('offset', String(offset));
+        if (category !== undefined && category !== '') {
+            params.set('category', category);
+        }
+        const response = await this.#http.get(`/files?${params.toString()}`, { noCache: true });
+        return this.#parse<FileListResponse>(response);
+    }
+
+    /**
+     * Удаляет файл по UUID. Соответствует DELETE /api/v1/files/:id. Сервер
+     * проверяет владение файлом; чужой файл вернёт 403.
+     * @param id - UUID файла
+     * @throws Error при HTTP не-2xx
+     */
+    public async deleteFile(id: string): Promise<void> {
+        const response = await this.#http.delete(`/files/${encodeURIComponent(id)}`);
+        if (!response.ok) {
+            const body = (await response.json().catch(() => ({}))) as { error?: string };
+            throw new Error(body.error ?? `HTTP ${String(response.status)}`);
+        }
+    }
+
+    /**
+     * Возвращает квоту и текущее потребление диска пользователя.
+     * Соответствует GET /api/v1/files/usage.
+     * @returns промис с FileUsageResponse (used/limit/plan/...)
+     * @throws Error при HTTP не-2xx
+     */
+    public async getUsage(): Promise<FileUsageResponse> {
+        const response = await this.#http.get('/files/usage', { noCache: true });
+        return this.#parse<FileUsageResponse>(response);
+    }
+
+    /**
+     * Админская выдача файлов. Соответствует GET /api/v1/admin/storage/files
+     * с фильтрами category и owner_id и пагинацией. Доступно только admin'у;
+     * для не-admin'ов сервер вернёт 403.
+     * @param params - объект фильтров
+     * @returns промис с FileListResponse
+     * @throws Error при HTTP не-2xx
+     */
+    public async adminListFiles(params: {
+        limit: number;
+        offset: number;
+        category?: string;
+        ownerId?: number;
+    }): Promise<FileListResponse> {
+        const qs = new URLSearchParams();
+        qs.set('limit', String(params.limit));
+        qs.set('offset', String(params.offset));
+        if (params.category !== undefined && params.category !== '') {
+            qs.set('category', params.category);
+        }
+        if (params.ownerId !== undefined && params.ownerId > 0) {
+            qs.set('owner_id', String(params.ownerId));
+        }
+        const response = await this.#http.get(`/admin/storage/files?${qs.toString()}`, {
+            noCache: true
+        });
+        return this.#parse<FileListResponse>(response);
+    }
+}

--- a/src/shared/api/StorageApi.ts
+++ b/src/shared/api/StorageApi.ts
@@ -1,5 +1,12 @@
 import { HttpClient } from '../http_client/HttpClient.js';
-import type { ApiEnvelope, FileItemDTO, FileListResponse, FileUsageResponse } from './types.js';
+import type {
+    ApiEnvelope,
+    FileItemDTO,
+    FileListResponse,
+    FileShareDTO,
+    FileShareListResponse,
+    FileUsageResponse
+} from './types.js';
 
 /**
  * API-клиент storage-сервиса: загрузка пользовательских файлов, листинг,
@@ -119,6 +126,144 @@ export class StorageApi {
      * с фильтрами category и owner_id и пагинацией. Доступно только admin'у;
      * для не-admin'ов сервер вернёт 403.
      * @param params - объект фильтров
+     * @returns промис с FileListResponse
+     * @throws Error при HTTP не-2xx
+     */
+    /**
+     * Загружает страницу файлов, расшаренных текущему пользователю.
+     * Соответствует GET /api/v1/files/shared?limit=&offset=.
+     * @param limit - размер страницы
+     * @param offset - смещение
+     * @returns промис со списком файлов
+     * @throws Error при HTTP не-2xx
+     */
+    public async listSharedWithMe(limit: number, offset: number): Promise<FileListResponse> {
+        const params = new URLSearchParams();
+        params.set('limit', String(limit));
+        params.set('offset', String(offset));
+        const response = await this.#http.get(`/files/shared?${params.toString()}`, {
+            noCache: true
+        });
+        return this.#parse<FileListResponse>(response);
+    }
+
+    /**
+     * Расшаривает файл по email или username. Соответствует
+     * POST /api/v1/files/:id/share. Если пользователь не найден на бэке —
+     * вернёт 404; уровень принимает 'view' или 'download'.
+     * @param fileId - UUID файла
+     * @param identifier - email или username получателя
+     * @param level - 'view' (без скачивания) или 'download'
+     * @returns промис с FileShareDTO выданного приглашения
+     * @throws Error при HTTP не-2xx
+     */
+    public async shareFile(
+        fileId: string,
+        identifier: string,
+        level: 'view' | 'download'
+    ): Promise<FileShareDTO> {
+        const response = await this.#http.post(`/files/${encodeURIComponent(fileId)}/share`, {
+            identifier,
+            level
+        });
+        return this.#parse<FileShareDTO>(response);
+    }
+
+    /**
+     * Возвращает список приглашений к файлу. Доступно только владельцу.
+     * @param fileId - UUID файла
+     * @returns промис со списком приглашений
+     * @throws Error при HTTP не-2xx
+     */
+    public async listShares(fileId: string): Promise<FileShareListResponse> {
+        const response = await this.#http.get(`/files/${encodeURIComponent(fileId)}/shares`, {
+            noCache: true
+        });
+        return this.#parse<FileShareListResponse>(response);
+    }
+
+    /**
+     * Меняет уровень доступа для уже приглашённого пользователя.
+     * @param fileId - UUID файла
+     * @param userId - ID пользователя
+     * @param level - новый уровень
+     * @returns промис с обновлённой записью
+     * @throws Error при HTTP не-2xx
+     */
+    public async updateShare(
+        fileId: string,
+        userId: number,
+        level: 'view' | 'download'
+    ): Promise<FileShareDTO> {
+        const response = await this.#http.put(
+            `/files/${encodeURIComponent(fileId)}/shares/${String(userId)}`,
+            { level }
+        );
+        return this.#parse<FileShareDTO>(response);
+    }
+
+    /**
+     * Отзывает доступ конкретного пользователя к файлу.
+     * @param fileId - UUID файла
+     * @param userId - ID пользователя
+     * @throws Error при HTTP не-2xx
+     */
+    public async revokeShare(fileId: string, userId: number): Promise<void> {
+        const response = await this.#http.delete(
+            `/files/${encodeURIComponent(fileId)}/shares/${String(userId)}`
+        );
+        if (!response.ok) {
+            const body = (await response.json().catch(() => ({}))) as { error?: string };
+            throw new Error(body.error ?? `HTTP ${String(response.status)}`);
+        }
+    }
+
+    /**
+     * Включает или выключает публичную ссылку. При включении бэк генерирует
+     * UUID-токен (вернётся в FileItemDTO.share_token); при выключении токен
+     * обнуляется и старая ссылка перестаёт работать.
+     * @param fileId - UUID файла
+     * @param isPublic - true — выдать публичную ссылку, false — отозвать
+     * @param expiresAt - ISO-дата истечения (опционально, только при isPublic=true)
+     * @returns промис с обновлённой записью файла
+     * @throws Error при HTTP не-2xx
+     */
+    public async setPublic(
+        fileId: string,
+        isPublic: boolean,
+        expiresAt?: string | null
+    ): Promise<FileItemDTO> {
+        const payload: Record<string, unknown> = { is_public: isPublic };
+        if (expiresAt !== undefined && expiresAt !== null && expiresAt !== '') {
+            payload.expires_at = expiresAt;
+        }
+        const response = await this.#http.put(
+            `/files/${encodeURIComponent(fileId)}/public`,
+            payload
+        );
+        return this.#parse<FileItemDTO>(response);
+    }
+
+    /**
+     * Переименовывает файл (меняется только отображаемое имя; storage_key и
+     * прямой URL остаются прежними, поэтому существующие ссылки на файл
+     * продолжают работать).
+     * @param fileId - UUID файла
+     * @param filename - новое имя (1..255, без / и \)
+     * @returns промис с обновлённым DTO
+     * @throws Error при HTTP не-2xx (например 400 при недопустимом имени)
+     */
+    public async renameFile(fileId: string, filename: string): Promise<FileItemDTO> {
+        const response = await this.#http.patch(`/files/${encodeURIComponent(fileId)}/rename`, {
+            filename
+        });
+        return this.#parse<FileItemDTO>(response);
+    }
+
+    /**
+     * Админская выдача файлов. Соответствует GET /api/v1/admin/storage/files
+     * с фильтрами category и owner_id и пагинацией. Доступно только admin'у.
+     * @param params - объект фильтров (limit, offset, category?, ownerId?)
      * @returns промис с FileListResponse
      * @throws Error при HTTP не-2xx
      */

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -556,6 +556,8 @@ export interface FileItemDTO {
     download_url: string;
     /** Публичный URL для скачивания (если is_public) */
     public_url?: string | null;
+    /** Email владельца (заполняется для расшаренных файлов; для своих может быть пустым) */
+    owner_email?: string;
 }
 
 /**

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -517,6 +517,59 @@ export interface NotebookEventDTO {
     message?: string;
 }
 
+// ===== Storage / Files =====
+
+/**
+ * DTO одного файла из storage-сервиса. Соответствует ответу
+ * /api/v1/files/* и AdminFile в админ-листинге (за исключением owner_username).
+ */
+export interface FileItemDTO {
+    /** UUID файла */
+    id: string;
+    /** ID владельца */
+    owner_id: number;
+    /** ID notebook'а (если файл прикреплён к notebook) */
+    notebook_id?: number;
+    /** Категория ('files', 'avatars', 'feedback', 'datasets') */
+    category: string;
+    /** Имя файла как ввёл пользователь */
+    filename: string;
+    /** Путь для скачивания (например /uploads/files/uuid.ext) */
+    url: string;
+    /** MIME-тип определённый по содержимому */
+    mime_type: string;
+    /** Размер в байтах */
+    size: number;
+    /** ISO-дата создания */
+    created_at: string;
+}
+
+/**
+ * Ответ /api/v1/files со списком файлов и общим числом для пагинации.
+ */
+export interface FileListResponse {
+    /** Найденные файлы (страница) */
+    files: FileItemDTO[];
+    /** Общее количество */
+    total: number;
+}
+
+/**
+ * Ответ /api/v1/files/usage с информацией о квоте текущего пользователя.
+ */
+export interface FileUsageResponse {
+    /** Использовано байт */
+    used: number;
+    /** Лимит байт (для admin берётся служебное большое число) */
+    limit: number;
+    /** true если у пользователя безлимитная квота (admin) */
+    unlimited: boolean;
+    /** Тариф пользователя ('free', 'pro', 'max', 'admin', 'freeze') */
+    plan: string;
+    /** Количество файлов пользователя */
+    files_count: number;
+}
+
 // ===== Streaming (websocket runtime errors / output chunks) =====
 
 /**

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -542,6 +542,44 @@ export interface FileItemDTO {
     size: number;
     /** ISO-дата создания */
     created_at: string;
+    /** Файл опубликован публичной ссылкой */
+    is_public: boolean;
+    /** UUID public-токена, если файл опубликован */
+    share_token?: string | null;
+    /** ISO-дата истечения public-ссылки */
+    share_expires_at?: string | null;
+    /** Количество скачиваний (всех каналов) */
+    downloads_count: number;
+    /** Уровень доступа текущего пользователя: owner/view/download/public */
+    your_permission?: string;
+    /** Авторизованный URL для скачивания */
+    download_url: string;
+    /** Публичный URL для скачивания (если is_public) */
+    public_url?: string | null;
+}
+
+/**
+ * DTO записи о расшаривании файла конкретному пользователю.
+ */
+export interface FileShareDTO {
+    /** UUID файла */
+    file_id: string;
+    /** ID пользователя, которому выдан доступ */
+    user_id: number;
+    /** Email приглашённого (заполняется на бэке) */
+    email?: string;
+    /** Уровень доступа: 'view' или 'download' */
+    permission_level: 'view' | 'download';
+    /** ISO-дата выдачи доступа */
+    created_at: string;
+}
+
+/**
+ * Ответ /api/v1/files/:id/shares — список приглашений к файлу.
+ */
+export interface FileShareListResponse {
+    /** Приглашения */
+    shares: FileShareDTO[];
 }
 
 /**

--- a/src/shared/utils/formatBytes.ts
+++ b/src/shared/utils/formatBytes.ts
@@ -1,0 +1,23 @@
+/**
+ * Форматирует размер в байтах в человеко-читаемую строку: 'B' / 'KB' / 'MB' / 'GB'.
+ * Используется в виджетах disk-table, disk-usage-card и админ-секции файлов.
+ * @param bytes - количество байт (целое неотрицательное число)
+ * @param precision - количество знаков после запятой (по умолчанию 1)
+ * @returns форматированная строка (например '12.3 MB')
+ */
+export function formatBytes(bytes: number, precision = 1): string {
+    if (bytes < 0 || !Number.isFinite(bytes)) {
+        return '0 B';
+    }
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let value = bytes;
+    let unitIndex = 0;
+    while (value >= 1024 && unitIndex < units.length - 1) {
+        value /= 1024;
+        unitIndex += 1;
+    }
+    if (unitIndex === 0) {
+        return `${String(value)} ${units[unitIndex]}`;
+    }
+    return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}

--- a/src/widgets/admin-files-section/AdminFilesSection.scss
+++ b/src/widgets/admin-files-section/AdminFilesSection.scss
@@ -1,0 +1,75 @@
+.admin-files-table {
+    background: #fff;
+    border-radius: 8px;
+    padding: 8px 16px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.admin-data-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.admin-data-table th {
+    text-align: left;
+    font-size: 13px;
+    color: #5a6a5c;
+    padding: 10px 8px;
+    border-bottom: 1px solid #eaeaea;
+}
+
+.admin-data-table td {
+    padding: 10px 8px;
+    border-bottom: 1px solid #f3f3f3;
+    font-size: 13px;
+    color: #2e3a2f;
+}
+
+.admin-data-table a {
+    color: #2e7233;
+    text-decoration: none;
+}
+
+.admin-data-table a:hover {
+    text-decoration: underline;
+}
+
+.admin-action--danger {
+    background: #fff;
+    border: 1px solid #e9b8af;
+    color: #b03a2e;
+    border-radius: 6px;
+    padding: 4px 10px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.admin-action--danger:hover {
+    background: #fbeae6;
+}
+
+.admin-pagination {
+    margin-top: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.admin-pagination button {
+    background: #fff;
+    border: 1px solid #d0dad1;
+    border-radius: 6px;
+    padding: 4px 10px;
+    cursor: pointer;
+}
+
+.admin-pagination button[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.admin-empty {
+    padding: 24px;
+    text-align: center;
+    color: #6a7a6c;
+}

--- a/src/widgets/admin-files-section/AdminFilesSection.ts
+++ b/src/widgets/admin-files-section/AdminFilesSection.ts
@@ -1,0 +1,234 @@
+import { StorageApi } from '../../shared/api/StorageApi.js';
+import type { FileItemDTO } from '../../shared/api/types.js';
+import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+import { formatBytes } from '../../shared/utils/formatBytes.js';
+import { logError } from '../../shared/utils/logger.js';
+
+const PAGE_SIZE = 20;
+const CATEGORIES = ['', 'files', 'avatars', 'feedback', 'datasets'];
+
+/**
+ * Секция «Файлы» в админ-панели. Показывает все файлы пользователей с
+ * фильтрами по категории и владельцу (owner_id), пагинацией и кнопкой
+ * «Удалить» на каждой строке. Использует существующий админ-эндпоинт
+ * /api/v1/admin/storage/files (gateway → storage gRPC AdminListFiles).
+ */
+export class AdminFilesSection {
+    #parent: HTMLElement;
+    #storage: StorageApi;
+    #currentPage = 1;
+    #category = '';
+    #ownerId: number | null = null;
+    #total = 0;
+    #files: FileItemDTO[] = [];
+
+    /**
+     * Сохраняет родительский элемент и инициализирует StorageApi singleton.
+     * @param parent - элемент, в который будет вставлен контент секции
+     */
+    public constructor(parent: HTMLElement) {
+        this.#parent = parent;
+        this.#storage = StorageApi.getInstance();
+    }
+
+    /**
+     * Рендерит структуру секции и запускает первую загрузку. Слушатели
+     * вешаются на новые элементы.
+     */
+    public mount(): void {
+        const title = document.createElement('h2');
+        title.className = 'admin-page__section-title';
+        title.textContent = 'Файлы';
+        this.#parent.appendChild(title);
+
+        const filters = document.createElement('div');
+        filters.className = 'admin-table-header';
+        filters.innerHTML = `
+            <select class="admin-search" data-role="category">
+                <option value="">Все категории</option>
+                <option value="files">files</option>
+                <option value="avatars">avatars</option>
+                <option value="feedback">feedback</option>
+                <option value="datasets">datasets</option>
+            </select>
+            <input class="admin-search" type="number" min="0" placeholder="ID владельца" data-role="owner" />
+            <button class="admin-action" type="button" data-role="apply">Применить</button>
+            <span class="admin-count" data-role="count"></span>
+        `;
+        this.#parent.appendChild(filters);
+
+        const table = document.createElement('div');
+        table.className = 'admin-files-table';
+        this.#parent.appendChild(table);
+
+        const pagination = document.createElement('div');
+        pagination.className = 'admin-pagination';
+        this.#parent.appendChild(pagination);
+
+        filters
+            .querySelector<HTMLButtonElement>('[data-role="apply"]')
+            ?.addEventListener('click', () => {
+                const cat =
+                    filters.querySelector<HTMLSelectElement>('[data-role="category"]')?.value ?? '';
+                const ownerStr =
+                    filters.querySelector<HTMLInputElement>('[data-role="owner"]')?.value ?? '';
+                this.#category = CATEGORIES.includes(cat) ? cat : '';
+                const ownerNum = Number.parseInt(ownerStr, 10);
+                this.#ownerId = Number.isFinite(ownerNum) && ownerNum > 0 ? ownerNum : null;
+                this.#currentPage = 1;
+                void this.#refresh();
+            });
+
+        void this.#refresh();
+    }
+
+    /**
+     * Размонтирует секцию: очищает содержимое родителя (слушатели на самих
+     * элементах удалятся вместе с innerHTML).
+     */
+    public unmount(): void {
+        this.#parent.innerHTML = '';
+    }
+
+    /**
+     * Подгружает текущую страницу с учётом фильтров и перерисовывает таблицу
+     * + пагинацию.
+     */
+    async #refresh(): Promise<void> {
+        try {
+            const offset = (this.#currentPage - 1) * PAGE_SIZE;
+            const resp = await this.#storage.adminListFiles({
+                limit: PAGE_SIZE,
+                offset,
+                category: this.#category === '' ? undefined : this.#category,
+                ownerId: this.#ownerId ?? undefined
+            });
+            this.#files = resp.files;
+            this.#total = resp.total;
+            this.#renderTable();
+            this.#renderPagination();
+            this.#renderCount();
+        } catch (error: unknown) {
+            logError('AdminFilesSection.refresh failed', error);
+        }
+    }
+
+    /**
+     * Перерисовывает таблицу файлов: empty-state, заголовки, строки с кнопкой
+     * удалить.
+     */
+    #renderTable(): void {
+        const table = this.#parent.querySelector<HTMLElement>('.admin-files-table');
+        if (!table) return;
+
+        if (this.#files.length === 0) {
+            table.innerHTML = '<div class="admin-empty">Файлы не найдены</div>';
+            return;
+        }
+
+        const rowsHtml = this.#files
+            .map((file) => {
+                const safeName = escapeHtml(file.filename);
+                const safeUrl = escapeHtml(file.url);
+                const safeMime = escapeHtml(file.mime_type);
+                const safeCat = escapeHtml(file.category);
+                const date = new Date(file.created_at).toLocaleString('ru-RU');
+                return `<tr data-id="${escapeHtml(file.id)}">
+                    <td><a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeName}</a></td>
+                    <td>${String(file.owner_id)}</td>
+                    <td>${safeCat}</td>
+                    <td>${safeMime}</td>
+                    <td>${formatBytes(file.size)}</td>
+                    <td>${date}</td>
+                    <td><button type="button" class="admin-action admin-action--danger" data-role="delete">Удалить</button></td>
+                </tr>`;
+            })
+            .join('');
+
+        table.innerHTML = `<table class="admin-data-table">
+            <thead>
+                <tr>
+                    <th>Имя</th>
+                    <th>owner_id</th>
+                    <th>Категория</th>
+                    <th>MIME</th>
+                    <th>Размер</th>
+                    <th>Дата</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>${rowsHtml}</tbody>
+        </table>`;
+
+        table.querySelectorAll<HTMLButtonElement>('[data-role="delete"]').forEach((btn) => {
+            btn.addEventListener('click', (event: Event) => {
+                const row = (event.currentTarget as HTMLElement).closest<HTMLElement>('tr');
+                const id = row?.dataset.id ?? '';
+                const file = this.#files.find((f) => f.id === id);
+                if (file) void this.#handleDelete(file);
+            });
+        });
+    }
+
+    /**
+     * Рендерит простую пагинацию (prev/next + номер страницы). Для админки
+     * не нужен сложный paginator из shared/components.
+     */
+    #renderPagination(): void {
+        const container = this.#parent.querySelector<HTMLElement>('.admin-pagination');
+        if (!container) return;
+        const totalPages = Math.max(1, Math.ceil(this.#total / PAGE_SIZE));
+        if (totalPages <= 1) {
+            container.innerHTML = '';
+            return;
+        }
+        container.innerHTML = `
+            <button type="button" data-role="prev" ${this.#currentPage === 1 ? 'disabled' : ''}>‹</button>
+            <span>${String(this.#currentPage)} / ${String(totalPages)}</span>
+            <button type="button" data-role="next" ${this.#currentPage >= totalPages ? 'disabled' : ''}>›</button>
+        `;
+        container
+            .querySelector<HTMLButtonElement>('[data-role="prev"]')
+            ?.addEventListener('click', () => {
+                if (this.#currentPage > 1) {
+                    this.#currentPage -= 1;
+                    void this.#refresh();
+                }
+            });
+        container
+            .querySelector<HTMLButtonElement>('[data-role="next"]')
+            ?.addEventListener('click', () => {
+                if (this.#currentPage < totalPages) {
+                    this.#currentPage += 1;
+                    void this.#refresh();
+                }
+            });
+    }
+
+    /**
+     * Обновляет счётчик «Всего N» в фильтре.
+     */
+    #renderCount(): void {
+        const el = this.#parent.querySelector<HTMLElement>('[data-role="count"]');
+        if (el) el.textContent = `Всего: ${String(this.#total)}`;
+    }
+
+    /**
+     * Спрашивает подтверждение и удаляет файл админ-эндпоинтом. После
+     * удачного удаления — refresh.
+     * @param file - файл к удалению
+     */
+    async #handleDelete(file: FileItemDTO): Promise<void> {
+        // eslint-disable-next-line no-alert -- admin-side confirmation; modal redesign is a separate task
+        const ok = window.confirm(
+            `Удалить "${file.filename}" пользователя ${String(file.owner_id)}?`
+        );
+        if (!ok) return;
+        try {
+            await this.#storage.deleteFile(file.id);
+            await this.#refresh();
+        } catch (error: unknown) {
+            logError('AdminFilesSection.delete failed', error);
+        }
+    }
+}

--- a/src/widgets/disk-table/DiskTable.scss
+++ b/src/widgets/disk-table/DiskTable.scss
@@ -1,0 +1,84 @@
+.disk-table {
+    width: 100%;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+    padding: 8px 16px 16px;
+}
+
+.disk-table__table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.disk-table__header-row th {
+    text-align: left;
+    font-size: 13px;
+    font-weight: 500;
+    color: #5a6a5c;
+    padding: 12px 8px;
+    border-bottom: 1px solid #eaeaea;
+}
+
+.disk-table__row td {
+    padding: 12px 8px;
+    border-bottom: 1px solid #f3f3f3;
+    font-size: 14px;
+    color: #2e3a2f;
+    vertical-align: middle;
+}
+
+.disk-table__row:hover td {
+    background: #f9fbf9;
+}
+
+.disk-table__name {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.disk-table__name a {
+    color: #2e7233;
+    text-decoration: none;
+}
+
+.disk-table__name a:hover {
+    text-decoration: underline;
+}
+
+.disk-table__actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.disk-table__action {
+    background: none;
+    border: 1px solid transparent;
+    color: #2e7233;
+    cursor: pointer;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 13px;
+}
+
+.disk-table__action:hover {
+    background: #eaf6ec;
+    border-color: #c2dac4;
+}
+
+.disk-table__action_delete {
+    color: #b03a2e;
+}
+
+.disk-table__action_delete:hover {
+    background: #fbeae6;
+    border-color: #e9b8af;
+}
+
+.disk-table__empty {
+    text-align: center;
+    color: #6a7a6c;
+    padding: 24px 16px;
+}

--- a/src/widgets/disk-table/DiskTable.scss
+++ b/src/widgets/disk-table/DiskTable.scss
@@ -1,14 +1,38 @@
 .disk-table {
+    box-sizing: border-box;
     width: 100%;
     background: #fff;
     border-radius: 12px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
     padding: 8px 16px 16px;
+    position: relative;
 }
 
 .disk-table__table {
     width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
+}
+
+.disk-table__header_name {
+    width: 32%;
+}
+
+.disk-table__header_owner {
+    width: 20%;
+}
+
+.disk-table__header_size,
+.disk-table__header_downloads {
+    width: 10%;
+}
+
+.disk-table__header_mime {
+    width: 12%;
+}
+
+.disk-table__header_date {
+    width: 16%;
 }
 
 .disk-table__header-row th {
@@ -26,55 +50,55 @@
     font-size: 14px;
     color: #2e3a2f;
     vertical-align: middle;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .disk-table__row:hover td {
     background: #f9fbf9;
 }
 
-.disk-table__name {
+.disk-table__cell-name {
+    min-width: 0;
+}
+
+.disk-table__name-wrap {
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
 }
 
-.disk-table__name a {
+.disk-table__cell-date {
+    color: #5a6a5c;
+}
+
+.disk-table__name-link {
     color: #2e7233;
     text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    flex: 1;
+    display: inline-block;
 }
 
-.disk-table__name a:hover {
+.disk-table__name-link:hover {
     text-decoration: underline;
 }
 
-.disk-table__actions {
-    display: flex;
-    gap: 8px;
-    justify-content: flex-end;
+.disk-table__cell-owner,
+.disk-table__cell-mime {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: #5a6a5c;
 }
 
-.disk-table__action {
-    background: none;
-    border: 1px solid transparent;
-    color: #2e7233;
-    cursor: pointer;
-    padding: 4px 10px;
-    border-radius: 6px;
-    font-size: 13px;
-}
-
-.disk-table__action:hover {
-    background: #eaf6ec;
-    border-color: #c2dac4;
-}
-
-.disk-table__action_delete {
-    color: #b03a2e;
-}
-
-.disk-table__action_delete:hover {
-    background: #fbeae6;
-    border-color: #e9b8af;
+.disk-table__cell-downloads {
+    text-align: center;
 }
 
 .disk-table__empty {
@@ -89,9 +113,9 @@
     border-radius: 999px;
     font-size: 11px;
     line-height: 1.2;
-    margin-left: 6px;
     background: #eaf6ec;
     color: #2e7233;
+    flex-shrink: 0;
 }
 
 .disk-table__badge_public {
@@ -102,41 +126,51 @@
 .disk-table__badge_count {
     background: #eef3ee;
     color: #5a6a5c;
-    margin-left: 0;
 }
 
-.disk-table__downloads {
-    text-align: center;
-}
-
-.disk-table__actions {
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-}
-
-.disk-table__action {
-    padding: 4px 8px;
-    border-radius: 6px;
-    border: 1px solid #d6e2d8;
+.disk-table__context-menu {
+    position: fixed;
+    z-index: 1200;
     background: #fff;
-    color: #2e3a2f;
-    font-size: 12px;
+    border: 1px solid #d6e2d8;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    padding: 4px;
+    min-width: 180px;
+    display: flex;
+    flex-direction: column;
+}
+
+.disk-table__context-menu[hidden] {
+    display: none;
+}
+
+.disk-table__menu-item {
+    text-align: left;
+    background: none;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 6px;
     cursor: pointer;
-    text-decoration: none;
-    line-height: 1.4;
+    font-size: 13px;
+    color: #2e3a2f;
 }
 
-.disk-table__action:hover:not([disabled]) {
-    background: #f4f8f4;
+.disk-table__menu-item:hover:not(:disabled) {
+    background: #eaf6ec;
 }
 
-.disk-table__action[disabled] {
+.disk-table__menu-item_danger {
+    color: #b03a2e;
+}
+
+.disk-table__menu-item_danger:hover:not(:disabled) {
+    background: #fbeae6;
+}
+
+.disk-table__menu-item_disabled,
+.disk-table__menu-item:disabled {
     opacity: 0.55;
     cursor: not-allowed;
-}
-
-.disk-table__action_delete {
-    border-color: #f1d1cf;
-    color: #b03a2e;
+    color: #5a6a5c;
 }

--- a/src/widgets/disk-table/DiskTable.scss
+++ b/src/widgets/disk-table/DiskTable.scss
@@ -82,3 +82,61 @@
     color: #6a7a6c;
     padding: 24px 16px;
 }
+
+.disk-table__badge {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 999px;
+    font-size: 11px;
+    line-height: 1.2;
+    margin-left: 6px;
+    background: #eaf6ec;
+    color: #2e7233;
+}
+
+.disk-table__badge_public {
+    background: #fff3d6;
+    color: #946400;
+}
+
+.disk-table__badge_count {
+    background: #eef3ee;
+    color: #5a6a5c;
+    margin-left: 0;
+}
+
+.disk-table__downloads {
+    text-align: center;
+}
+
+.disk-table__actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.disk-table__action {
+    padding: 4px 8px;
+    border-radius: 6px;
+    border: 1px solid #d6e2d8;
+    background: #fff;
+    color: #2e3a2f;
+    font-size: 12px;
+    cursor: pointer;
+    text-decoration: none;
+    line-height: 1.4;
+}
+
+.disk-table__action:hover:not([disabled]) {
+    background: #f4f8f4;
+}
+
+.disk-table__action[disabled] {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.disk-table__action_delete {
+    border-color: #f1d1cf;
+    color: #b03a2e;
+}

--- a/src/widgets/disk-table/DiskTable.template.ts
+++ b/src/widgets/disk-table/DiskTable.template.ts
@@ -1,7 +1,7 @@
 /**
- * Рендерит каркас таблицы файлов пользователя: заголовки (Имя/Размер/Тип/
- * Дата/Действия), пустой tbody (заполняется в DiskTable.setData) и
- * empty-state. Названия повторяют стиль FilesTable, чтобы UX был знакомым.
+ * Рендерит каркас таблицы файлов: имя, владелец, размер, тип, скачиваний,
+ * дата. Действия скрыты, для них используется контекстное меню по правой
+ * кнопке мыши на строке.
  * @returns HTML-разметка для innerHTML
  */
 export function DiskTableTemplate(): string {
@@ -9,16 +9,16 @@ export function DiskTableTemplate(): string {
     <table class="disk-table__table">
         <thead>
             <tr class="disk-table__header-row">
-                <th class="disk-table__header">Имя</th>
-                <th class="disk-table__header">Размер</th>
-                <th class="disk-table__header">Тип</th>
-                <th class="disk-table__header">Скачиваний</th>
-                <th class="disk-table__header">Дата</th>
-                <th class="disk-table__header disk-table__header_actions"></th>
+                <th class="disk-table__header disk-table__header_name">Имя</th>
+                <th class="disk-table__header disk-table__header_owner">Владелец</th>
+                <th class="disk-table__header disk-table__header_size">Размер</th>
+                <th class="disk-table__header disk-table__header_mime">Тип</th>
+                <th class="disk-table__header disk-table__header_downloads">Скачиваний</th>
+                <th class="disk-table__header disk-table__header_date">Дата</th>
             </tr>
         </thead>
         <tbody class="disk-table__body"></tbody>
     </table>
-    <div class="disk-table__empty" style="display:none;">У вас пока нет загруженных файлов</div>
+    <div class="disk-table__empty" style="display:none;">У вас пока нет файлов</div>
 </div>`;
 }

--- a/src/widgets/disk-table/DiskTable.template.ts
+++ b/src/widgets/disk-table/DiskTable.template.ts
@@ -1,0 +1,23 @@
+/**
+ * Рендерит каркас таблицы файлов пользователя: заголовки (Имя/Размер/Тип/
+ * Дата/Действия), пустой tbody (заполняется в DiskTable.setData) и
+ * empty-state. Названия повторяют стиль FilesTable, чтобы UX был знакомым.
+ * @returns HTML-разметка для innerHTML
+ */
+export function DiskTableTemplate(): string {
+    return `<div class="disk-table">
+    <table class="disk-table__table">
+        <thead>
+            <tr class="disk-table__header-row">
+                <th class="disk-table__header">Имя</th>
+                <th class="disk-table__header">Размер</th>
+                <th class="disk-table__header">Тип</th>
+                <th class="disk-table__header">Дата</th>
+                <th class="disk-table__header disk-table__header_actions"></th>
+            </tr>
+        </thead>
+        <tbody class="disk-table__body"></tbody>
+    </table>
+    <div class="disk-table__empty" style="display:none;">У вас пока нет загруженных файлов</div>
+</div>`;
+}

--- a/src/widgets/disk-table/DiskTable.template.ts
+++ b/src/widgets/disk-table/DiskTable.template.ts
@@ -12,6 +12,7 @@ export function DiskTableTemplate(): string {
                 <th class="disk-table__header">Имя</th>
                 <th class="disk-table__header">Размер</th>
                 <th class="disk-table__header">Тип</th>
+                <th class="disk-table__header">Скачиваний</th>
                 <th class="disk-table__header">Дата</th>
                 <th class="disk-table__header disk-table__header_actions"></th>
             </tr>

--- a/src/widgets/disk-table/DiskTable.ts
+++ b/src/widgets/disk-table/DiskTable.ts
@@ -6,23 +6,38 @@ import { nn } from '../../shared/utils/notNull.js';
 import { DiskTableTemplate } from './DiskTable.template.js';
 
 /**
- * Опции DiskTable — колбэк на удаление одной строки. Родитель обрабатывает
- * подтверждение и сам зовёт StorageApi.deleteFile.
+ * Опции DiskTable — колбэки на действия со строкой. Родитель сам подтверждает
+ * деструктивные действия и вызывает соответствующие методы StorageApi.
  */
 export interface DiskTableOptions {
     /**
-     * Колбэк вызывается при клике на «Удалить». Родитель должен спросить
-     * подтверждение (если нужно) и удалить файл через StorageApi, после чего
-     * обновить таблицу через setData.
+     * Колбэк удаления строки.
      * @param file - файл, на котором был клик
      */
     onDelete: (file: FileItemDTO) => void;
+    /**
+     * Колбэк открытия модалки шаринга. Опционален: на вкладке «расшарено
+     * со мной» не показываем кнопку «Поделиться».
+     * @param file - файл, для которого открыть ShareModal
+     */
+    onShare?: (file: FileItemDTO) => void;
+    /**
+     * Колбэк переименования. Опционален аналогично onShare.
+     * @param file - файл к переименованию
+     */
+    onRename?: (file: FileItemDTO) => void;
+    /**
+     * Режим отображения. 'own' — мои файлы (полный набор действий);
+     * 'shared' — файлы, расшаренные мне (только скачивание, без удаления/шаринга).
+     */
+    mode?: 'own' | 'shared';
 }
 
 /**
- * Таблица пользовательских файлов с колонками Имя/Размер/Тип/Дата/Действия.
- * Логика — простой setData(files) пересобирает tbody. Сортировка пока не нужна:
- * данные приходят с бэка уже отсортированные по created_at DESC.
+ * Таблица файлов: имя, размер, тип, число скачиваний, дата, действия.
+ * setData(files) пересобирает tbody; владельцу доступны действия
+ * Скачать/Поделиться/Переименовать/Удалить. На вкладке «расшарено со мной»
+ * показывается только Скачать (или disabled, если уровень view).
  */
 export class DiskTable extends BaseComponent {
     #options: DiskTableOptions;
@@ -31,7 +46,7 @@ export class DiskTable extends BaseComponent {
     /**
      * Создаёт виджет; реальная вставка в DOM — в mount().
      * @param parent - родительский DOM-элемент
-     * @param options - опции с колбэком onDelete
+     * @param options - опции с колбэками
      */
     public constructor(parent: HTMLElement, options: DiskTableOptions) {
         const root = document.createElement('div');
@@ -41,8 +56,7 @@ export class DiskTable extends BaseComponent {
     }
 
     /**
-     * Заменяет список файлов и перерисовывает tbody. Empty-state показывается
-     * автоматически когда files.length === 0.
+     * Заменяет список файлов и перерисовывает tbody.
      * @param files - новый список файлов
      */
     public setData(files: FileItemDTO[]): void {
@@ -51,9 +65,7 @@ export class DiskTable extends BaseComponent {
     }
 
     /**
-     * Пересобирает tbody таблицы из текущего this.#files. Слушатели для
-     * кнопок удаления навешиваются заново (предыдущие чистятся в
-     * _clearListeners при unmount; здесь мы переиспользуем _listeners).
+     * Пересобирает tbody таблицы из текущего this.#files.
      */
     #renderRows(): void {
         const body = nn(this._element.querySelector<HTMLElement>('.disk-table__body'));
@@ -66,37 +78,102 @@ export class DiskTable extends BaseComponent {
         }
 
         empty.style.display = 'none';
-        body.innerHTML = this.#files
-            .map((file) => {
-                const sizeStr = formatBytes(file.size);
-                const dateStr = new Date(file.created_at).toLocaleString('ru-RU');
-                const safeName = escapeHtml(file.filename);
-                const safeMime = escapeHtml(file.mime_type);
-                const safeUrl = escapeHtml(file.url);
-                return `<tr class="disk-table__row" data-id="${escapeHtml(file.id)}">
-                    <td class="disk-table__name">
-                        <a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeName}</a>
-                    </td>
-                    <td>${sizeStr}</td>
-                    <td>${safeMime}</td>
-                    <td>${dateStr}</td>
-                    <td class="disk-table__actions">
-                        <button type="button" class="disk-table__action disk-table__action_delete" data-action="delete">Удалить</button>
-                    </td>
-                </tr>`;
-            })
-            .join('');
+        const isShared = this.#options.mode === 'shared';
+        body.innerHTML = this.#files.map((file) => this.#renderRow(file, isShared)).join('');
+        this.#attachRowListeners(body);
+    }
 
-        body.querySelectorAll<HTMLButtonElement>('[data-action="delete"]').forEach((btn) => {
-            this._addListener(btn, 'click', (event: Event) => {
-                const row = (event.currentTarget as HTMLElement).closest<HTMLElement>(
-                    '.disk-table__row'
-                );
-                if (!row) return;
-                const id = row.dataset.id ?? '';
-                const file = this.#files.find((f) => f.id === id);
-                if (file) this.#options.onDelete(file);
-            });
+    /**
+     * Возвращает HTML одной строки.
+     * @param file - DTO файла
+     * @param isShared - режим вкладки «расшарено со мной»
+     * @returns HTML-разметка <tr>
+     */
+    #renderRow(file: FileItemDTO, isShared: boolean): string {
+        const sizeStr = formatBytes(file.size);
+        const dateStr = new Date(file.created_at).toLocaleString('ru-RU');
+        const safeName = escapeHtml(file.filename);
+        const safeMime = escapeHtml(file.mime_type);
+        const safeDownload = escapeHtml(file.download_url);
+        const downloadsBadge =
+            file.downloads_count > 0
+                ? `<span class="disk-table__badge disk-table__badge_count" title="Скачиваний">${String(
+                      file.downloads_count
+                  )}</span>`
+                : '';
+        const publicBadge = file.is_public
+            ? '<span class="disk-table__badge disk-table__badge_public" title="Доступно по публичной ссылке">Публичный</span>'
+            : '';
+
+        const actions = isShared
+            ? this.#renderSharedActions(file, safeDownload)
+            : this.#renderOwnActions(safeDownload);
+
+        return `<tr class="disk-table__row" data-id="${escapeHtml(file.id)}">
+            <td class="disk-table__name">
+                <a href="${safeDownload}" target="_blank" rel="noopener noreferrer">${safeName}</a>
+                ${publicBadge}
+            </td>
+            <td>${sizeStr}</td>
+            <td>${safeMime}</td>
+            <td class="disk-table__downloads">${downloadsBadge}</td>
+            <td>${dateStr}</td>
+            <td class="disk-table__actions">${actions}</td>
+        </tr>`;
+    }
+
+    /**
+     * Возвращает HTML действий для строк на вкладке «Мои файлы».
+     * @param downloadUrl - экранированный download_url
+     * @returns HTML-разметка действий
+     */
+    #renderOwnActions(downloadUrl: string): string {
+        const share = this.#options.onShare
+            ? `<button type="button" class="disk-table__action" data-action="share">Поделиться</button>`
+            : '';
+        const rename = this.#options.onRename
+            ? `<button type="button" class="disk-table__action" data-action="rename">Переименовать</button>`
+            : '';
+        return `
+            <a class="disk-table__action" href="${downloadUrl}" download>Скачать</a>
+            ${share}
+            ${rename}
+            <button type="button" class="disk-table__action disk-table__action_delete" data-action="delete">Удалить</button>
+        `;
+    }
+
+    /**
+     * Возвращает HTML действий для строк на вкладке «Расшарено со мной».
+     * View-only уровень — кнопка disabled с подсказкой.
+     * @param file - DTO файла
+     * @param downloadUrl - экранированный download_url
+     * @returns HTML-разметка действий
+     */
+    #renderSharedActions(file: FileItemDTO, downloadUrl: string): string {
+        if (file.your_permission === 'download') {
+            return `<a class="disk-table__action" href="${downloadUrl}" download>Скачать</a>`;
+        }
+        return `<button type="button" class="disk-table__action" disabled title="У вас только просмотр">Только просмотр</button>`;
+    }
+
+    /**
+     * Навешивает делегирование обработчиков на tbody — каждый клик по
+     * data-action="X" вызывает соответствующий callback.
+     * @param body - tbody таблицы
+     */
+    #attachRowListeners(body: HTMLElement): void {
+        this._addListener(body, 'click', (event: Event) => {
+            const btn = (event.target as HTMLElement).closest<HTMLElement>('[data-action]');
+            if (!btn) return;
+            const row = btn.closest<HTMLElement>('.disk-table__row');
+            if (!row) return;
+            const id = row.dataset.id ?? '';
+            const file = this.#files.find((f) => f.id === id);
+            if (!file) return;
+            const action = btn.dataset.action;
+            if (action === 'delete') this.#options.onDelete(file);
+            else if (action === 'share') this.#options.onShare?.(file);
+            else if (action === 'rename') this.#options.onRename?.(file);
         });
     }
 }

--- a/src/widgets/disk-table/DiskTable.ts
+++ b/src/widgets/disk-table/DiskTable.ts
@@ -6,42 +6,59 @@ import { nn } from '../../shared/utils/notNull.js';
 import { DiskTableTemplate } from './DiskTable.template.js';
 
 /**
- * Опции DiskTable — колбэки на действия со строкой. Родитель сам подтверждает
- * деструктивные действия и вызывает соответствующие методы StorageApi.
+ * Опции DiskTable — колбэки на действия. Все действия вызываются из
+ * контекстного меню (правая кнопка мыши на строке). Видимый набор зависит
+ * от прав текущего пользователя на конкретный файл: owner получает все
+ * действия, приглашённый с уровнем 'download' — только «Скачать»,
+ * приглашённый с уровнем 'view' — disabled-пункт-подсказку.
  */
 export interface DiskTableOptions {
     /**
-     * Колбэк удаления строки.
-     * @param file - файл, на котором был клик
+     * Колбэк удаления файла. Вызывается только для owner.
+     * @param file - файл к удалению
      */
     onDelete: (file: FileItemDTO) => void;
     /**
-     * Колбэк открытия модалки шаринга. Опционален: на вкладке «расшарено
-     * со мной» не показываем кнопку «Поделиться».
-     * @param file - файл, для которого открыть ShareModal
+     * Колбэк открытия модалки шаринга. Вызывается только для owner.
+     * @param file - файл для шаринга
      */
     onShare?: (file: FileItemDTO) => void;
     /**
-     * Колбэк переименования. Опционален аналогично onShare.
+     * Колбэк переименования. Вызывается только для owner.
      * @param file - файл к переименованию
      */
     onRename?: (file: FileItemDTO) => void;
-    /**
-     * Режим отображения. 'own' — мои файлы (полный набор действий);
-     * 'shared' — файлы, расшаренные мне (только скачивание, без удаления/шаринга).
-     */
-    mode?: 'own' | 'shared';
 }
 
 /**
- * Таблица файлов: имя, размер, тип, число скачиваний, дата, действия.
- * setData(files) пересобирает tbody; владельцу доступны действия
- * Скачать/Поделиться/Переименовать/Удалить. На вкладке «расшарено со мной»
- * показывается только Скачать (или disabled, если уровень view).
+ * Описание одного пункта контекстного меню. Действия маппятся в
+ * соответствующие колбэки DiskTableOptions.
+ */
+interface ContextMenuItem {
+    /** Видимая подпись пункта */
+    label: string;
+    /** Идентификатор действия для роутинга в обработчик */
+    action: 'download' | 'share' | 'rename' | 'delete';
+    /** Стилизовать пункт как деструктивный (красный) */
+    danger?: boolean;
+    /** Заблокирован ли пункт */
+    disabled?: boolean;
+    /** Tooltip-подсказка над пунктом */
+    title?: string;
+}
+
+/**
+ * Таблица файлов с одним общим списком (свои + расшаренные). Колонки:
+ * Имя, Владелец, Размер, Тип, Скачиваний, Дата. Длинные значения в первых
+ * двух колонках обрезаются ellipsis'ом. Действия — через контекстное меню
+ * по правой кнопке мыши.
  */
 export class DiskTable extends BaseComponent {
     #options: DiskTableOptions;
     #files: FileItemDTO[] = [];
+    #menuEl: HTMLElement | null = null;
+    #docClickHandler: ((e: MouseEvent) => void) | null = null;
+    #docKeyHandler: ((e: KeyboardEvent) => void) | null = null;
 
     /**
      * Создаёт виджет; реальная вставка в DOM — в mount().
@@ -56,8 +73,35 @@ export class DiskTable extends BaseComponent {
     }
 
     /**
+     * Размонтирует виджет, закрывает меню и убирает его из DOM (если было создано).
+     */
+    public override unmount(): void {
+        this.#closeMenu();
+        if (this.#menuEl !== null) {
+            this.#menuEl.remove();
+            this.#menuEl = null;
+        }
+        super.unmount();
+    }
+
+    /**
+     * Создаёт DOM-элемент меню при первом обращении и аппендит его к body,
+     * чтобы position:fixed не упирался ни в overflow ни в transformed-предков.
+     * @returns HTMLElement меню (свежесозданный или ранее созданный)
+     */
+    #ensureMenu(): HTMLElement {
+        if (this.#menuEl !== null) return this.#menuEl;
+        const el = document.createElement('div');
+        el.className = 'disk-table__context-menu';
+        el.hidden = true;
+        document.body.appendChild(el);
+        this.#menuEl = el;
+        return el;
+    }
+
+    /**
      * Заменяет список файлов и перерисовывает tbody.
-     * @param files - новый список файлов
+     * @param files - новый список (смешанный: свои + расшаренные)
      */
     public setData(files: FileItemDTO[]): void {
         this.#files = files;
@@ -65,7 +109,8 @@ export class DiskTable extends BaseComponent {
     }
 
     /**
-     * Пересобирает tbody таблицы из текущего this.#files.
+     * Пересобирает tbody таблицы из текущего this.#files. Внутри ставит
+     * делегированные слушатели click и contextmenu на tbody.
      */
     #renderRows(): void {
         const body = nn(this._element.querySelector<HTMLElement>('.disk-table__body'));
@@ -76,28 +121,27 @@ export class DiskTable extends BaseComponent {
             empty.style.display = 'block';
             return;
         }
-
         empty.style.display = 'none';
-        const isShared = this.#options.mode === 'shared';
-        body.innerHTML = this.#files.map((file) => this.#renderRow(file, isShared)).join('');
+        body.innerHTML = this.#files.map((file) => this.#renderRow(file)).join('');
         this.#attachRowListeners(body);
     }
 
     /**
      * Возвращает HTML одной строки.
      * @param file - DTO файла
-     * @param isShared - режим вкладки «расшарено со мной»
      * @returns HTML-разметка <tr>
      */
-    #renderRow(file: FileItemDTO, isShared: boolean): string {
+    #renderRow(file: FileItemDTO): string {
         const sizeStr = formatBytes(file.size);
         const dateStr = new Date(file.created_at).toLocaleString('ru-RU');
         const safeName = escapeHtml(file.filename);
         const safeMime = escapeHtml(file.mime_type);
         const safeDownload = escapeHtml(file.download_url);
+        const ownerLabel = this.#ownerLabel(file);
+        const safeOwner = escapeHtml(ownerLabel);
         const downloadsBadge =
             file.downloads_count > 0
-                ? `<span class="disk-table__badge disk-table__badge_count" title="Скачиваний">${String(
+                ? `<span class="disk-table__badge disk-table__badge_count">${String(
                       file.downloads_count
                   )}</span>`
                 : '';
@@ -105,75 +149,221 @@ export class DiskTable extends BaseComponent {
             ? '<span class="disk-table__badge disk-table__badge_public" title="Доступно по публичной ссылке">Публичный</span>'
             : '';
 
-        const actions = isShared
-            ? this.#renderSharedActions(file, safeDownload)
-            : this.#renderOwnActions(safeDownload);
-
         return `<tr class="disk-table__row" data-id="${escapeHtml(file.id)}">
-            <td class="disk-table__name">
-                <a href="${safeDownload}" target="_blank" rel="noopener noreferrer">${safeName}</a>
-                ${publicBadge}
+            <td class="disk-table__cell-name">
+                <div class="disk-table__name-wrap">
+                    <a class="disk-table__name-link" href="${safeDownload}" target="_blank" rel="noopener noreferrer" title="${safeName}">${safeName}</a>
+                    ${publicBadge}
+                </div>
             </td>
+            <td class="disk-table__cell-owner" title="${safeOwner}">${safeOwner}</td>
             <td>${sizeStr}</td>
-            <td>${safeMime}</td>
-            <td class="disk-table__downloads">${downloadsBadge}</td>
-            <td>${dateStr}</td>
-            <td class="disk-table__actions">${actions}</td>
+            <td class="disk-table__cell-mime" title="${safeMime}">${safeMime}</td>
+            <td class="disk-table__cell-downloads">${downloadsBadge}</td>
+            <td class="disk-table__cell-date">${dateStr}</td>
         </tr>`;
     }
 
     /**
-     * Возвращает HTML действий для строк на вкладке «Мои файлы».
-     * @param downloadUrl - экранированный download_url
-     * @returns HTML-разметка действий
-     */
-    #renderOwnActions(downloadUrl: string): string {
-        const share = this.#options.onShare
-            ? `<button type="button" class="disk-table__action" data-action="share">Поделиться</button>`
-            : '';
-        const rename = this.#options.onRename
-            ? `<button type="button" class="disk-table__action" data-action="rename">Переименовать</button>`
-            : '';
-        return `
-            <a class="disk-table__action" href="${downloadUrl}" download>Скачать</a>
-            ${share}
-            ${rename}
-            <button type="button" class="disk-table__action disk-table__action_delete" data-action="delete">Удалить</button>
-        `;
-    }
-
-    /**
-     * Возвращает HTML действий для строк на вкладке «Расшарено со мной».
-     * View-only уровень — кнопка disabled с подсказкой.
+     * Вычисляет подпись владельца: «Я» для собственных файлов (owner или
+     * пустой your_permission), иначе email из owner_email или fallback по id.
      * @param file - DTO файла
-     * @param downloadUrl - экранированный download_url
-     * @returns HTML-разметка действий
+     * @returns подпись для колонки «Владелец»
      */
-    #renderSharedActions(file: FileItemDTO, downloadUrl: string): string {
-        if (file.your_permission === 'download') {
-            return `<a class="disk-table__action" href="${downloadUrl}" download>Скачать</a>`;
+    #ownerLabel(file: FileItemDTO): string {
+        if (file.your_permission === 'owner' || file.your_permission === undefined) {
+            return 'Я';
         }
-        return `<button type="button" class="disk-table__action" disabled title="У вас только просмотр">Только просмотр</button>`;
+        if (file.owner_email !== undefined && file.owner_email !== '') {
+            return file.owner_email;
+        }
+        return `Пользователь #${String(file.owner_id)}`;
     }
 
     /**
-     * Навешивает делегирование обработчиков на tbody — каждый клик по
-     * data-action="X" вызывает соответствующий callback.
+     * Навешивает делегирование на tbody: левый клик по имени — нативный
+     * download (через <a>), правый клик — контекстное меню.
      * @param body - tbody таблицы
      */
     #attachRowListeners(body: HTMLElement): void {
-        this._addListener(body, 'click', (event: Event) => {
-            const btn = (event.target as HTMLElement).closest<HTMLElement>('[data-action]');
-            if (!btn) return;
-            const row = btn.closest<HTMLElement>('.disk-table__row');
+        this._addListener(body, 'contextmenu', (event: Event) => {
+            const e = event as MouseEvent;
+            const row = (e.target as HTMLElement).closest<HTMLElement>('.disk-table__row');
             if (!row) return;
             const id = row.dataset.id ?? '';
             const file = this.#files.find((f) => f.id === id);
             if (!file) return;
-            const action = btn.dataset.action;
-            if (action === 'delete') this.#options.onDelete(file);
-            else if (action === 'share') this.#options.onShare?.(file);
-            else if (action === 'rename') this.#options.onRename?.(file);
+            e.preventDefault();
+            this.#openMenu(file, e.clientX, e.clientY);
         });
+    }
+
+    /**
+     * Строит и показывает контекстное меню рядом с курсором. Меню
+     * позиционируется относительно viewport (position: fixed), его пункты
+     * зависят от прав на конкретный файл.
+     * @param file - файл, на котором кликнули правой кнопкой
+     * @param clientX - координата X курсора
+     * @param clientY - координата Y курсора
+     */
+    #openMenu(file: FileItemDTO, clientX: number, clientY: number): void {
+        const menu = this.#ensureMenu();
+        const items = this.#buildMenuItems(file);
+        menu.innerHTML = items
+            .map((item) => {
+                const classes = [
+                    'disk-table__menu-item',
+                    item.danger === true ? 'disk-table__menu-item_danger' : '',
+                    item.disabled === true ? 'disk-table__menu-item_disabled' : ''
+                ]
+                    .filter(Boolean)
+                    .join(' ');
+                const titleAttr =
+                    item.title !== undefined ? ` title="${escapeHtml(item.title)}"` : '';
+                return `<button type="button" class="${classes}" data-action="${item.action}" data-id="${escapeHtml(file.id)}"${titleAttr}${item.disabled === true ? ' disabled' : ''}>${escapeHtml(item.label)}</button>`;
+            })
+            .join('');
+        menu.hidden = false;
+        const { x, y } = this.#clampMenuPosition(clientX, clientY, menu);
+        menu.style.left = `${String(x)}px`;
+        menu.style.top = `${String(y)}px`;
+
+        menu.onclick = (event): void => {
+            const btn = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-action]');
+            if (!btn || btn.disabled) return;
+            this.#handleMenuAction(file, btn.dataset.action ?? '');
+            this.#closeMenu();
+        };
+
+        this.#installGlobalCloseListeners();
+    }
+
+    /**
+     * Собирает список пунктов меню в зависимости от прав на файл.
+     * @param file - DTO файла
+     * @returns массив пунктов
+     */
+    #buildMenuItems(file: FileItemDTO): ContextMenuItem[] {
+        const isOwner = file.your_permission === 'owner' || file.your_permission === undefined;
+        if (isOwner) {
+            const items: ContextMenuItem[] = [{ label: 'Скачать', action: 'download' }];
+            if (this.#options.onShare) items.push({ label: 'Поделиться', action: 'share' });
+            if (this.#options.onRename) items.push({ label: 'Переименовать', action: 'rename' });
+            items.push({ label: 'Удалить', action: 'delete', danger: true });
+            return items;
+        }
+        if (file.your_permission === 'view') {
+            return [
+                {
+                    label: 'Только просмотр',
+                    action: 'download',
+                    disabled: true,
+                    title: 'У вас нет права на скачивание'
+                }
+            ];
+        }
+        return [{ label: 'Скачать', action: 'download' }];
+    }
+
+    /**
+     * Корректирует положение меню так, чтобы оно не вылезало за правый/нижний
+     * край viewport.
+     * @param x - желаемая координата X
+     * @param y - желаемая координата Y
+     * @param menu - элемент меню (для измерения размеров)
+     * @returns скорректированные координаты
+     */
+    #clampMenuPosition(x: number, y: number, menu: HTMLElement): { x: number; y: number } {
+        const rect = menu.getBoundingClientRect();
+        const maxX = window.innerWidth - rect.width - 4;
+        const maxY = window.innerHeight - rect.height - 4;
+        return {
+            x: Math.min(x, Math.max(0, maxX)),
+            y: Math.min(y, Math.max(0, maxY))
+        };
+    }
+
+    /**
+     * Навешивает глобальные слушатели на document для закрытия меню по клику
+     * вне его и по Escape. Сохраняет ссылки, чтобы потом снять.
+     */
+    #installGlobalCloseListeners(): void {
+        this.#removeGlobalCloseListeners();
+        this.#docClickHandler = (e: MouseEvent): void => {
+            const menu = this.#menuEl;
+            if (menu === null || menu.hidden === true) return;
+            if (e.target instanceof Node && menu.contains(e.target)) return;
+            this.#closeMenu();
+        };
+        this.#docKeyHandler = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') this.#closeMenu();
+        };
+        document.addEventListener('click', this.#docClickHandler, { capture: true });
+        document.addEventListener('contextmenu', this.#docClickHandler, { capture: true });
+        document.addEventListener('keydown', this.#docKeyHandler);
+    }
+
+    /**
+     * Снимает глобальные слушатели документа.
+     */
+    #removeGlobalCloseListeners(): void {
+        if (this.#docClickHandler) {
+            document.removeEventListener('click', this.#docClickHandler, { capture: true });
+            document.removeEventListener('contextmenu', this.#docClickHandler, { capture: true });
+            this.#docClickHandler = null;
+        }
+        if (this.#docKeyHandler) {
+            document.removeEventListener('keydown', this.#docKeyHandler);
+            this.#docKeyHandler = null;
+        }
+    }
+
+    /**
+     * Закрывает меню и снимает глобальные слушатели.
+     */
+    #closeMenu(): void {
+        if (this.#menuEl !== null) {
+            this.#menuEl.hidden = true;
+            this.#menuEl.innerHTML = '';
+        }
+        this.#removeGlobalCloseListeners();
+    }
+
+    /**
+     * Обрабатывает выбранный пункт меню.
+     * @param file - файл, на котором было меню
+     * @param action - выбранное действие
+     */
+    #handleMenuAction(file: FileItemDTO, action: string): void {
+        switch (action) {
+            case 'download':
+                this.#triggerDownload(file);
+                break;
+            case 'share':
+                this.#options.onShare?.(file);
+                break;
+            case 'rename':
+                this.#options.onRename?.(file);
+                break;
+            case 'delete':
+                this.#options.onDelete(file);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Программно инициирует скачивание через временный <a download>.
+     * @param file - файл к скачиванию
+     */
+    #triggerDownload(file: FileItemDTO): void {
+        const a = document.createElement('a');
+        a.href = file.download_url;
+        a.download = file.filename;
+        a.rel = 'noopener noreferrer';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
     }
 }

--- a/src/widgets/disk-table/DiskTable.ts
+++ b/src/widgets/disk-table/DiskTable.ts
@@ -1,0 +1,102 @@
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import type { FileItemDTO } from '../../shared/api/types.js';
+import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+import { formatBytes } from '../../shared/utils/formatBytes.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { DiskTableTemplate } from './DiskTable.template.js';
+
+/**
+ * Опции DiskTable — колбэк на удаление одной строки. Родитель обрабатывает
+ * подтверждение и сам зовёт StorageApi.deleteFile.
+ */
+export interface DiskTableOptions {
+    /**
+     * Колбэк вызывается при клике на «Удалить». Родитель должен спросить
+     * подтверждение (если нужно) и удалить файл через StorageApi, после чего
+     * обновить таблицу через setData.
+     * @param file - файл, на котором был клик
+     */
+    onDelete: (file: FileItemDTO) => void;
+}
+
+/**
+ * Таблица пользовательских файлов с колонками Имя/Размер/Тип/Дата/Действия.
+ * Логика — простой setData(files) пересобирает tbody. Сортировка пока не нужна:
+ * данные приходят с бэка уже отсортированные по created_at DESC.
+ */
+export class DiskTable extends BaseComponent {
+    #options: DiskTableOptions;
+    #files: FileItemDTO[] = [];
+
+    /**
+     * Создаёт виджет; реальная вставка в DOM — в mount().
+     * @param parent - родительский DOM-элемент
+     * @param options - опции с колбэком onDelete
+     */
+    public constructor(parent: HTMLElement, options: DiskTableOptions) {
+        const root = document.createElement('div');
+        root.innerHTML = DiskTableTemplate();
+        super(root.firstElementChild as HTMLElement, parent);
+        this.#options = options;
+    }
+
+    /**
+     * Заменяет список файлов и перерисовывает tbody. Empty-state показывается
+     * автоматически когда files.length === 0.
+     * @param files - новый список файлов
+     */
+    public setData(files: FileItemDTO[]): void {
+        this.#files = files;
+        this.#renderRows();
+    }
+
+    /**
+     * Пересобирает tbody таблицы из текущего this.#files. Слушатели для
+     * кнопок удаления навешиваются заново (предыдущие чистятся в
+     * _clearListeners при unmount; здесь мы переиспользуем _listeners).
+     */
+    #renderRows(): void {
+        const body = nn(this._element.querySelector<HTMLElement>('.disk-table__body'));
+        const empty = nn(this._element.querySelector<HTMLElement>('.disk-table__empty'));
+
+        if (this.#files.length === 0) {
+            body.innerHTML = '';
+            empty.style.display = 'block';
+            return;
+        }
+
+        empty.style.display = 'none';
+        body.innerHTML = this.#files
+            .map((file) => {
+                const sizeStr = formatBytes(file.size);
+                const dateStr = new Date(file.created_at).toLocaleString('ru-RU');
+                const safeName = escapeHtml(file.filename);
+                const safeMime = escapeHtml(file.mime_type);
+                const safeUrl = escapeHtml(file.url);
+                return `<tr class="disk-table__row" data-id="${escapeHtml(file.id)}">
+                    <td class="disk-table__name">
+                        <a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeName}</a>
+                    </td>
+                    <td>${sizeStr}</td>
+                    <td>${safeMime}</td>
+                    <td>${dateStr}</td>
+                    <td class="disk-table__actions">
+                        <button type="button" class="disk-table__action disk-table__action_delete" data-action="delete">Удалить</button>
+                    </td>
+                </tr>`;
+            })
+            .join('');
+
+        body.querySelectorAll<HTMLButtonElement>('[data-action="delete"]').forEach((btn) => {
+            this._addListener(btn, 'click', (event: Event) => {
+                const row = (event.currentTarget as HTMLElement).closest<HTMLElement>(
+                    '.disk-table__row'
+                );
+                if (!row) return;
+                const id = row.dataset.id ?? '';
+                const file = this.#files.find((f) => f.id === id);
+                if (file) this.#options.onDelete(file);
+            });
+        });
+    }
+}

--- a/src/widgets/disk-usage-card/DiskUsageCard.scss
+++ b/src/widgets/disk-usage-card/DiskUsageCard.scss
@@ -75,6 +75,11 @@
     flex: 0 0 auto;
 }
 
+.disk-usage-card_inset {
+    max-width: 480px;
+    align-self: flex-start;
+}
+
 .disk-usage-card_compact .disk-usage-card__header {
     margin-bottom: 6px;
 }

--- a/src/widgets/disk-usage-card/DiskUsageCard.scss
+++ b/src/widgets/disk-usage-card/DiskUsageCard.scss
@@ -1,4 +1,5 @@
 .disk-usage-card {
+    box-sizing: border-box;
     background: #fff;
     border: 1px solid #e6efe7;
     border-radius: 12px;

--- a/src/widgets/disk-usage-card/DiskUsageCard.scss
+++ b/src/widgets/disk-usage-card/DiskUsageCard.scss
@@ -75,11 +75,6 @@
     flex: 0 0 auto;
 }
 
-.disk-usage-card_inset {
-    max-width: 480px;
-    align-self: flex-start;
-}
-
 .disk-usage-card_compact .disk-usage-card__header {
     margin-bottom: 6px;
 }

--- a/src/widgets/disk-usage-card/DiskUsageCard.scss
+++ b/src/widgets/disk-usage-card/DiskUsageCard.scss
@@ -67,3 +67,34 @@
     transform: translateY(-1px);
     border-color: #c2dac4;
 }
+
+.disk-usage-card_compact {
+    padding: 10px 14px;
+    margin-bottom: 12px;
+    align-self: flex-start;
+    width: 100%;
+    max-width: 480px;
+    flex: 0 0 auto;
+}
+
+.disk-usage-card_compact .disk-usage-card__header {
+    margin-bottom: 6px;
+}
+
+.disk-usage-card_compact .disk-usage-card__title {
+    font-size: 13px;
+}
+
+.disk-usage-card_compact .disk-usage-card__plan {
+    font-size: 11px;
+    padding: 1px 6px;
+}
+
+.disk-usage-card_compact .disk-usage-card__bar {
+    height: 5px;
+}
+
+.disk-usage-card_compact .disk-usage-card__footer {
+    margin-top: 6px;
+    font-size: 12px;
+}

--- a/src/widgets/disk-usage-card/DiskUsageCard.scss
+++ b/src/widgets/disk-usage-card/DiskUsageCard.scss
@@ -71,9 +71,7 @@
 .disk-usage-card_compact {
     padding: 10px 14px;
     margin-bottom: 12px;
-    align-self: flex-start;
     width: 100%;
-    max-width: 480px;
     flex: 0 0 auto;
 }
 

--- a/src/widgets/disk-usage-card/DiskUsageCard.scss
+++ b/src/widgets/disk-usage-card/DiskUsageCard.scss
@@ -1,0 +1,69 @@
+.disk-usage-card {
+    background: #fff;
+    border: 1px solid #e6efe7;
+    border-radius: 12px;
+    padding: 16px 20px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.disk-usage-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.disk-usage-card__title {
+    font-weight: 600;
+    color: #2e3a2f;
+    font-size: 15px;
+}
+
+.disk-usage-card__plan {
+    font-size: 12px;
+    color: #2e7233;
+    background: #eaf6ec;
+    padding: 2px 8px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.disk-usage-card__bar {
+    background: #eef3ee;
+    border-radius: 999px;
+    height: 8px;
+    overflow: hidden;
+}
+
+.disk-usage-card__bar-fill {
+    background: linear-gradient(90deg, #6abf73 0%, #2e7233 100%);
+    height: 100%;
+    transition: width 0.25s ease;
+}
+
+.disk-usage-card__bar-fill_warn {
+    background: linear-gradient(90deg, #f0a83a 0%, #c97a14 100%);
+}
+
+.disk-usage-card__bar-fill_danger {
+    background: linear-gradient(90deg, #e96360 0%, #b03a2e 100%);
+}
+
+.disk-usage-card__footer {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 8px;
+    font-size: 13px;
+    color: #5a6a5c;
+}
+
+.disk-usage-card_clickable {
+    cursor: pointer;
+    transition: transform 0.1s ease;
+}
+
+.disk-usage-card_clickable:hover {
+    transform: translateY(-1px);
+    border-color: #c2dac4;
+}

--- a/src/widgets/disk-usage-card/DiskUsageCard.template.ts
+++ b/src/widgets/disk-usage-card/DiskUsageCard.template.ts
@@ -1,0 +1,20 @@
+/**
+ * Рендерит карточку заполненности диска с прогресс-баром и подписями.
+ * Динамические значения вставляются DiskUsageCard.refresh.
+ * @returns HTML-разметка для innerHTML
+ */
+export function DiskUsageCardTemplate(): string {
+    return `<div class="disk-usage-card">
+    <div class="disk-usage-card__header">
+        <div class="disk-usage-card__title">Диск</div>
+        <div class="disk-usage-card__plan"></div>
+    </div>
+    <div class="disk-usage-card__bar">
+        <div class="disk-usage-card__bar-fill" style="width:0%"></div>
+    </div>
+    <div class="disk-usage-card__footer">
+        <span class="disk-usage-card__usage"></span>
+        <span class="disk-usage-card__count"></span>
+    </div>
+</div>`;
+}

--- a/src/widgets/disk-usage-card/DiskUsageCard.ts
+++ b/src/widgets/disk-usage-card/DiskUsageCard.ts
@@ -17,11 +17,18 @@ export interface DiskUsageCardOptions {
      */
     onClick?: () => void;
     /**
-     * Включает компактный вариант: меньший padding, кегль, высота бара и
-     * ограниченная max-width. Используется когда карточка встраивается в
-     * страницу со своим контентом (например /files), а не как hero-блок.
+     * Включает компактный вариант: меньший padding, кегль, высота бара.
+     * Используется когда карточка встраивается в страницу со своим
+     * контентом (например /files), а не как hero-блок.
      */
     compact?: boolean;
+    /**
+     * Включает inset-вариант: ограничивает max-width так, чтобы карточка
+     * не растягивалась на всю ширину секции. Применяется в подпунктах
+     * страниц (например в секции «Хранилище» профиля), где рядом стоят
+     * другие компактные карточки и full-width смотрится диспропорционально.
+     */
+    inset?: boolean;
 }
 
 /**
@@ -57,6 +64,9 @@ export class DiskUsageCard extends BaseComponent {
         super.mount();
         if (this.#options.compact === true) {
             this._element.classList.add('disk-usage-card_compact');
+        }
+        if (this.#options.inset === true) {
+            this._element.classList.add('disk-usage-card_inset');
         }
         if (this.#options.onClick) {
             this._element.classList.add('disk-usage-card_clickable');

--- a/src/widgets/disk-usage-card/DiskUsageCard.ts
+++ b/src/widgets/disk-usage-card/DiskUsageCard.ts
@@ -1,0 +1,124 @@
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import { StorageApi } from '../../shared/api/StorageApi.js';
+import type { FileUsageResponse } from '../../shared/api/types.js';
+import { formatBytes } from '../../shared/utils/formatBytes.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { logError } from '../../shared/utils/logger.js';
+import { DiskUsageCardTemplate } from './DiskUsageCard.template.js';
+
+/**
+ * Опции DiskUsageCard: опциональный onClick делает карточку кликабельной
+ * (например на главной — клик ведёт на /disk).
+ */
+export interface DiskUsageCardOptions {
+    /**
+     * Колбэк клика по карточке. Если задан — карточка становится кликабельной
+     * (cursor: pointer, hover-эффект).
+     */
+    onClick?: () => void;
+}
+
+/**
+ * Виджет «карточка заполненности диска»: прогресс-бар + текст «использовано
+ * X из Y» + бейдж тарифа. Сам обращается к StorageApi.getUsage и
+ * перерисовывается. Родитель вызывает refresh() после загрузки/удаления.
+ *
+ * Цвет полоски меняется в зависимости от процента: зелёный <70%, жёлтый
+ * 70–90%, красный >=90%.
+ */
+export class DiskUsageCard extends BaseComponent {
+    #options: DiskUsageCardOptions;
+    #storage: StorageApi;
+
+    /**
+     * Создаёт карточку. Реальная вставка и первый запрос — в mount().
+     * @param parent - родительский DOM-элемент
+     * @param options - опции (onClick опционально)
+     */
+    public constructor(parent: HTMLElement, options: DiskUsageCardOptions = {}) {
+        const root = document.createElement('div');
+        root.innerHTML = DiskUsageCardTemplate();
+        super(root.firstElementChild as HTMLElement, parent);
+        this.#options = options;
+        this.#storage = StorageApi.getInstance();
+    }
+
+    /**
+     * Монтирует виджет, навешивает click-обработчик если задан onClick и
+     * запускает первый refresh.
+     */
+    public override mount(): void {
+        super.mount();
+        if (this.#options.onClick) {
+            this._element.classList.add('disk-usage-card_clickable');
+            this._addListener(this._element, 'click', () => {
+                this.#options.onClick?.();
+            });
+        }
+        void this.refresh();
+    }
+
+    /**
+     * Подтягивает свежие данные с бэка и перерисовывает прогресс-бар, надписи,
+     * бейдж тарифа. При ошибке оставляет последние видимые значения и
+     * пишет ошибку в лог (нет смысла мигать пустыми значениями при флапающем
+     * соединении).
+     */
+    public async refresh(): Promise<void> {
+        try {
+            const usage = await this.#storage.getUsage();
+            this.#render(usage);
+        } catch (error: unknown) {
+            logError('DiskUsageCard.refresh failed', error);
+        }
+    }
+
+    /**
+     * Применяет данные usage к DOM: ширина полоски, текст использования,
+     * бейдж тарифа, класс цвета.
+     * @param usage - данные с бэка о квоте
+     */
+    #render(usage: FileUsageResponse): void {
+        const fill = nn(this._element.querySelector<HTMLElement>('.disk-usage-card__bar-fill'));
+        const planLabel = nn(this._element.querySelector<HTMLElement>('.disk-usage-card__plan'));
+        const usageLabel = nn(this._element.querySelector<HTMLElement>('.disk-usage-card__usage'));
+        const countLabel = nn(this._element.querySelector<HTMLElement>('.disk-usage-card__count'));
+
+        const limitForLabel = usage.unlimited ? null : usage.limit;
+        const percent =
+            usage.unlimited || usage.limit <= 0
+                ? 0
+                : Math.min(100, Math.round((usage.used / usage.limit) * 100));
+
+        fill.style.width = `${String(percent)}%`;
+        fill.classList.remove('disk-usage-card__bar-fill_warn', 'disk-usage-card__bar-fill_danger');
+        if (percent >= 90) {
+            fill.classList.add('disk-usage-card__bar-fill_danger');
+        } else if (percent >= 70) {
+            fill.classList.add('disk-usage-card__bar-fill_warn');
+        }
+
+        planLabel.textContent = usage.plan || 'free';
+
+        if (limitForLabel === null) {
+            usageLabel.textContent = `${formatBytes(usage.used)} использовано`;
+        } else {
+            usageLabel.textContent = `${formatBytes(usage.used)} из ${formatBytes(limitForLabel)}`;
+        }
+        countLabel.textContent = `${String(usage.files_count)} ${this.#pluralFiles(usage.files_count)}`;
+    }
+
+    /**
+     * Возвращает корректную русскую форму слова «файл» для числительного.
+     * @param n - количество файлов
+     * @returns 'файл' / 'файла' / 'файлов'
+     */
+    #pluralFiles(n: number): string {
+        const mod10 = n % 10;
+        const mod100 = n % 100;
+        if (mod100 >= 11 && mod100 <= 14) return 'файлов';
+        if (mod10 === 1) return 'файл';
+        if (mod10 >= 2 && mod10 <= 4) return 'файла';
+        return 'файлов';
+    }
+}

--- a/src/widgets/disk-usage-card/DiskUsageCard.ts
+++ b/src/widgets/disk-usage-card/DiskUsageCard.ts
@@ -110,9 +110,9 @@ export class DiskUsageCard extends BaseComponent {
         planLabel.textContent = usage.plan || 'free';
 
         if (limitForLabel === null) {
-            usageLabel.textContent = `${formatBytes(usage.used)} использовано`;
+            usageLabel.textContent = `${formatBytes(usage.used)} использовано (безлимит)`;
         } else {
-            usageLabel.textContent = `${formatBytes(usage.used)} из ${formatBytes(limitForLabel)}`;
+            usageLabel.textContent = `${formatBytes(usage.used)} использовано из ${formatBytes(limitForLabel)}`;
         }
         countLabel.textContent = `${String(usage.files_count)} ${this.#pluralFiles(usage.files_count)}`;
     }

--- a/src/widgets/disk-usage-card/DiskUsageCard.ts
+++ b/src/widgets/disk-usage-card/DiskUsageCard.ts
@@ -22,13 +22,6 @@ export interface DiskUsageCardOptions {
      * контентом (например /files), а не как hero-блок.
      */
     compact?: boolean;
-    /**
-     * Включает inset-вариант: ограничивает max-width так, чтобы карточка
-     * не растягивалась на всю ширину секции. Применяется в подпунктах
-     * страниц (например в секции «Хранилище» профиля), где рядом стоят
-     * другие компактные карточки и full-width смотрится диспропорционально.
-     */
-    inset?: boolean;
 }
 
 /**
@@ -64,9 +57,6 @@ export class DiskUsageCard extends BaseComponent {
         super.mount();
         if (this.#options.compact === true) {
             this._element.classList.add('disk-usage-card_compact');
-        }
-        if (this.#options.inset === true) {
-            this._element.classList.add('disk-usage-card_inset');
         }
         if (this.#options.onClick) {
             this._element.classList.add('disk-usage-card_clickable');

--- a/src/widgets/disk-usage-card/DiskUsageCard.ts
+++ b/src/widgets/disk-usage-card/DiskUsageCard.ts
@@ -16,6 +16,12 @@ export interface DiskUsageCardOptions {
      * (cursor: pointer, hover-эффект).
      */
     onClick?: () => void;
+    /**
+     * Включает компактный вариант: меньший padding, кегль, высота бара и
+     * ограниченная max-width. Используется когда карточка встраивается в
+     * страницу со своим контентом (например /files), а не как hero-блок.
+     */
+    compact?: boolean;
 }
 
 /**
@@ -49,6 +55,9 @@ export class DiskUsageCard extends BaseComponent {
      */
     public override mount(): void {
         super.mount();
+        if (this.#options.compact === true) {
+            this._element.classList.add('disk-usage-card_compact');
+        }
         if (this.#options.onClick) {
             this._element.classList.add('disk-usage-card_clickable');
             this._addListener(this._element, 'click', () => {

--- a/src/widgets/file-drop-zone/FileDropZone.scss
+++ b/src/widgets/file-drop-zone/FileDropZone.scss
@@ -1,0 +1,77 @@
+.file-drop-zone {
+    border: 2px dashed #c2dac4;
+    border-radius: 12px;
+    background: #f7fbf7;
+    padding: 32px 24px;
+    text-align: center;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+    cursor: pointer;
+    outline: none;
+}
+
+.file-drop-zone:hover,
+.file-drop-zone:focus-visible,
+.file-drop-zone_dragover {
+    background: #eaf6ec;
+    border-color: #6abf73;
+}
+
+.file-drop-zone__inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.file-drop-zone__icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: #d8ecd9;
+    color: #2e7233;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 28px;
+    font-weight: 600;
+}
+
+.file-drop-zone__title {
+    font-size: 16px;
+    font-weight: 500;
+    color: #2e3a2f;
+}
+
+.file-drop-zone__subtitle {
+    font-size: 14px;
+    color: #6a7a6c;
+}
+
+.file-drop-zone__button {
+    border: 1px solid #6abf73;
+    background: #fff;
+    color: #2e7233;
+    padding: 6px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.file-drop-zone__button:hover {
+    background: #e6f4e8;
+}
+
+.file-drop-zone__status {
+    min-height: 18px;
+    font-size: 13px;
+    color: #4a5a4c;
+    margin-top: 4px;
+}
+
+.file-drop-zone__status_error {
+    color: #b03a2e;
+}
+
+.file-drop-zone__status_ok {
+    color: #2e7233;
+}

--- a/src/widgets/file-drop-zone/FileDropZone.template.ts
+++ b/src/widgets/file-drop-zone/FileDropZone.template.ts
@@ -1,0 +1,18 @@
+/**
+ * Рендерит контейнер drag-and-drop зоны для загрузки файлов с подсказкой и
+ * скрытым input[type=file]. Заполнение состояния (loading/error/idle) делает
+ * FileDropZone в рантайме.
+ * @returns HTML-разметка для innerHTML
+ */
+export function FileDropZoneTemplate(): string {
+    return `<div class="file-drop-zone" tabindex="0">
+    <div class="file-drop-zone__inner">
+        <div class="file-drop-zone__icon">+</div>
+        <div class="file-drop-zone__title">Перетащите файлы сюда</div>
+        <div class="file-drop-zone__subtitle">или</div>
+        <button type="button" class="file-drop-zone__button">Выбрать файл</button>
+        <input type="file" class="file-drop-zone__input" multiple hidden />
+        <div class="file-drop-zone__status" aria-live="polite"></div>
+    </div>
+</div>`;
+}

--- a/src/widgets/file-drop-zone/FileDropZone.ts
+++ b/src/widgets/file-drop-zone/FileDropZone.ts
@@ -1,0 +1,144 @@
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { FileDropZoneTemplate } from './FileDropZone.template.js';
+
+/**
+ * Опции FileDropZone — список колбэков для родителя (DiskPage).
+ */
+export interface FileDropZoneOptions {
+    /**
+     * Колбэк вызывается с массивом File после выбора файлов через диалог
+     * или после drop. Родитель должен загрузить файлы и обновить UI.
+     * @param files - выбранные пользователем файлы
+     */
+    onFiles: (files: File[]) => Promise<void>;
+}
+
+/**
+ * Виджет drag-and-drop зоны для загрузки файлов. Слушает dragenter/dragover/
+ * dragleave/drop на корневом элементе, click на кнопке "Выбрать файл" и change
+ * на скрытом input. Сам не загружает файлы — отдаёт массив File в колбэк.
+ *
+ * Состояние (loading/ok/error) меняет текст блока .file-drop-zone__status —
+ * для базовой обратной связи. Прогресс загрузки не показывает, потому что
+ * HttpClient.upload() не отдаёт ProgressEvent.
+ */
+export class FileDropZone extends BaseComponent {
+    #options: FileDropZoneOptions;
+    #dragCounter = 0;
+
+    /**
+     * Создаёт виджет и сразу подготавливает DOM (innerHTML).
+     * Реальная вставка в родителя происходит в mount().
+     * @param parent - родительский DOM-элемент
+     * @param options - опции с колбэком onFiles
+     */
+    public constructor(parent: HTMLElement, options: FileDropZoneOptions) {
+        const root = document.createElement('div');
+        root.innerHTML = FileDropZoneTemplate();
+        super(root.firstElementChild as HTMLElement, parent);
+        this.#options = options;
+    }
+
+    /**
+     * Монтирует виджет и развешивает слушатели drag/drop/click/change.
+     * Должен вызываться один раз — повторный mount без unmount даст дубль
+     * слушателей.
+     */
+    public override mount(): void {
+        super.mount();
+
+        const root = this._element;
+        const button = nn(root.querySelector<HTMLButtonElement>('.file-drop-zone__button'));
+        const input = nn(root.querySelector<HTMLInputElement>('.file-drop-zone__input'));
+
+        this._addListener(button, 'click', () => {
+            input.click();
+        });
+        this._addListener(input, 'change', () => {
+            this.#handleInputChange(input);
+        });
+
+        this._addListener(root, 'dragenter', this.#onDragEnter as EventListener);
+        this._addListener(root, 'dragover', this.#onDragOver as EventListener);
+        this._addListener(root, 'dragleave', this.#onDragLeave as EventListener);
+        this._addListener(root, 'drop', this.#onDrop as EventListener);
+    }
+
+    /**
+     * Устанавливает текст статуса под кнопкой и подсвечивает его цветом.
+     * Используется родителем для сообщений об ошибках/успехе после загрузки.
+     * @param text - текст сообщения (пустая строка чтобы скрыть)
+     * @param level - 'ok' / 'error' / 'info' (по умолчанию 'info')
+     */
+    public setStatus(text: string, level: 'ok' | 'error' | 'info' = 'info'): void {
+        const status = this._element.querySelector<HTMLElement>('.file-drop-zone__status');
+        if (!status) return;
+        status.textContent = text;
+        status.classList.remove('file-drop-zone__status_ok', 'file-drop-zone__status_error');
+        if (level === 'ok') status.classList.add('file-drop-zone__status_ok');
+        if (level === 'error') status.classList.add('file-drop-zone__status_error');
+    }
+
+    /**
+     * Обрабатывает change на скрытом input: вытаскивает FileList, очищает
+     * input.value (чтобы повторный выбор того же файла снова триггерил change)
+     * и отдаёт массив File в колбэк onFiles.
+     * @param input - элемент input из которого читаются файлы
+     */
+    #handleInputChange(input: HTMLInputElement): void {
+        const list = input.files;
+        if (!list || list.length === 0) return;
+        const files = Array.from(list);
+        input.value = '';
+        void this.#options.onFiles(files);
+    }
+
+    /**
+     * Реакция на dragenter: считает уровень вложенности (счётчик нужен,
+     * потому что dragenter/dragleave стреляют на каждом дочернем элементе),
+     * подсвечивает зону.
+     * @param event - DragEvent
+     */
+    #onDragEnter = (event: DragEvent): void => {
+        event.preventDefault();
+        this.#dragCounter += 1;
+        this._element.classList.add('file-drop-zone_dragover');
+    };
+
+    /**
+     * Реакция на dragover: блокирует дефолт чтобы получить событие drop.
+     * @param event - DragEvent
+     */
+    #onDragOver = (event: DragEvent): void => {
+        event.preventDefault();
+    };
+
+    /**
+     * Реакция на dragleave: уменьшает счётчик; когда он обнулится — снимает
+     * подсветку. Так избегаем «прыжков» при пересечении границ дочерних
+     * элементов.
+     * @param event - DragEvent
+     */
+    #onDragLeave = (event: DragEvent): void => {
+        event.preventDefault();
+        this.#dragCounter = Math.max(0, this.#dragCounter - 1);
+        if (this.#dragCounter === 0) {
+            this._element.classList.remove('file-drop-zone_dragover');
+        }
+    };
+
+    /**
+     * Реакция на drop: вытаскивает файлы из dataTransfer, сбрасывает счётчик
+     * и подсветку, отдаёт массив в onFiles.
+     * @param event - DragEvent
+     */
+    #onDrop = (event: DragEvent): void => {
+        event.preventDefault();
+        this.#dragCounter = 0;
+        this._element.classList.remove('file-drop-zone_dragover');
+        const list = event.dataTransfer?.files;
+        if (!list || list.length === 0) return;
+        void this.#options.onFiles(Array.from(list));
+    };
+}

--- a/src/widgets/file-drop-zone/FileDropZone.ts
+++ b/src/widgets/file-drop-zone/FileDropZone.ts
@@ -63,6 +63,9 @@ export class FileDropZone extends BaseComponent {
         this._addListener(root, 'dragover', this.#onDragOver as EventListener);
         this._addListener(root, 'dragleave', this.#onDragLeave as EventListener);
         this._addListener(root, 'drop', this.#onDrop as EventListener);
+
+        this._addListener(window, 'dragover', this.#onWindowDragOver as EventListener);
+        this._addListener(window, 'drop', this.#onWindowDrop as EventListener);
     }
 
     /**
@@ -107,10 +110,36 @@ export class FileDropZone extends BaseComponent {
     };
 
     /**
-     * Реакция на dragover: блокирует дефолт чтобы получить событие drop.
+     * Реакция на dragover: блокирует дефолт чтобы получить событие drop и
+     * выставляет dropEffect=copy, чтобы курсор показывал валидную drop-цель.
      * @param event - DragEvent
      */
     #onDragOver = (event: DragEvent): void => {
+        event.preventDefault();
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'copy';
+        }
+    };
+
+    /**
+     * Глобальный dragover на window: блокирует дефолтное поведение браузера
+     * (открытие файла в новой вкладке), если пользователь промахнулся мимо зоны.
+     * Без этого drop вне зоны просто откроет файл в браузере.
+     * @param event - DragEvent
+     */
+    #onWindowDragOver = (event: DragEvent): void => {
+        event.preventDefault();
+    };
+
+    /**
+     * Глобальный drop на window: блокирует дефолтное поведение для drop'ов
+     * вне зоны. Если drop пришёл на саму зону — событие уже обработано
+     * (preventDefault там), поэтому здесь только страхует промахи.
+     * @param event - DragEvent
+     */
+    #onWindowDrop = (event: DragEvent): void => {
+        const target = event.target as Node | null;
+        if (target && this._element.contains(target)) return;
         event.preventDefault();
     };
 

--- a/src/widgets/file-share-modal/FileShareModal.scss
+++ b/src/widgets/file-share-modal/FileShareModal.scss
@@ -1,0 +1,367 @@
+.file-share-modal__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 16px;
+}
+
+.file-share-modal {
+    background: var(--white);
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+    width: 100%;
+    max-width: 460px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.file-share-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 20px 14px;
+    border-bottom: 1px solid var(--cell-border);
+}
+
+.file-share-modal__title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--dark-primary);
+    margin: 0;
+}
+
+.file-share-modal__close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--accent);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.file-share-modal__close-btn:hover {
+    background: var(--light-grey);
+    color: var(--dark-primary);
+}
+
+.file-share-modal__body {
+    padding: 0 20px;
+    overflow-y: auto;
+    max-height: 60vh;
+}
+
+.file-share-modal__section {
+    padding: 16px 0;
+    border-bottom: 1px solid var(--cell-border);
+}
+
+.file-share-modal__section:last-child {
+    border-bottom: none;
+}
+
+.file-share-modal__label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--dark-primary);
+    margin-bottom: 8px;
+}
+
+.file-share-modal__input-row {
+    display: flex;
+    gap: 8px;
+}
+
+.file-share-modal__input {
+    flex: 1;
+    height: 36px;
+    padding: 0 10px;
+    border: 1.5px solid var(--cell-border);
+    border-radius: 6px;
+    font-size: 13px;
+    color: var(--dark-primary);
+    background: var(--white);
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.file-share-modal__input:focus {
+    border-color: var(--teal-green);
+}
+
+.file-share-modal__add-btn {
+    height: 36px;
+    padding: 0 16px;
+    border: none;
+    border-radius: 6px;
+    background: var(--teal-green);
+    color: var(--white);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: opacity 0.15s;
+}
+
+.file-share-modal__add-btn:hover {
+    opacity: 0.85;
+}
+
+.file-share-modal__add-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.file-share-modal__error {
+    margin-top: 6px;
+    font-size: 12px;
+    color: #d93025;
+}
+
+.file-share-modal__section--list {
+    min-height: 40px;
+}
+
+.file-share-modal__collaborators {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.file-share-modal__collaborator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    background: var(--light-grey);
+}
+
+.file-share-modal__collaborator-email {
+    font-size: 13px;
+    color: var(--dark-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+.file-share-modal__collaborator-level {
+    height: 28px;
+    padding: 0 6px;
+    border: 1.5px solid var(--cell-border);
+    border-radius: 6px;
+    font-size: 12px;
+    color: var(--dark-primary);
+    background: var(--white);
+    outline: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: border-color 0.15s;
+}
+
+.file-share-modal__collaborator-level:focus {
+    border-color: var(--grey);
+}
+
+.file-share-modal__remove-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--accent);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.file-share-modal__remove-btn:hover {
+    background: var(--light-grey);
+    color: #d93025;
+}
+
+.file-share-modal__empty {
+    font-size: 13px;
+    color: var(--accent);
+    margin: 0;
+}
+
+.file-share-modal__section--public {
+    padding: 14px 0;
+}
+
+.file-share-modal__public-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.file-share-modal__public-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.file-share-modal__public-label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--dark-primary);
+}
+
+.file-share-modal__public-hint {
+    font-size: 12px;
+    color: var(--accent);
+}
+
+.file-share-modal__toggle {
+    position: relative;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    cursor: pointer;
+}
+
+.file-share-modal__toggle-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.file-share-modal__toggle-track {
+    display: flex;
+    align-items: center;
+    width: 40px;
+    height: 21px;
+    border-radius: 20px;
+    background: var(--cell-border);
+    transition: background 0.2s;
+    padding: 3px;
+}
+
+.file-share-modal__toggle-input:checked + .file-share-modal__toggle-track {
+    background: var(--teal-green);
+}
+
+.file-share-modal__toggle-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--white);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: transform 0.2s;
+}
+
+.file-share-modal__toggle-input:checked + .file-share-modal__toggle-track .file-share-modal__toggle-thumb {
+    transform: translateX(20px);
+}
+
+.file-share-modal__footer {
+    display: flex;
+    align-items: center;
+    padding: 14px 20px;
+    border-top: 1px solid var(--cell-border);
+}
+
+.file-share-modal__copy-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    height: 34px;
+    padding: 0 14px;
+    border: 1.5px solid var(--cell-border);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--dark-primary);
+    font-size: 13px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.file-share-modal__copy-btn:hover {
+    border-color: var(--teal-green);
+    color: var(--teal-green);
+}
+
+.file-share-modal__copy-btn--success {
+    border-color: var(--teal-green);
+    color: var(--teal-green);
+}
+
+.file-share-modal__lifetime {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.file-share-modal__lifetime-label {
+    font-size: 12px;
+    color: #5a6a5c;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.file-share-modal__lifetime-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.file-share-modal__lifetime-option {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.file-share-modal__link-row {
+    display: flex;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.file-share-modal__link-input {
+    flex: 1 1 auto;
+    padding: 6px 10px;
+    border: 1px solid #d6e2d8;
+    border-radius: 6px;
+    font-size: 13px;
+    background: #f4f8f4;
+    color: #2e3a2f;
+}
+
+.file-share-modal__link-input:disabled {
+    background: #eef3ee;
+    color: #9aa89c;
+}
+
+.file-share-modal__level-select {
+    padding: 6px 8px;
+    border: 1px solid #d6e2d8;
+    border-radius: 6px;
+    font-size: 13px;
+    background: #fff;
+}
+
+.file-share-modal__copy-btn--success {
+    background: #6abf73 !important;
+    color: #fff !important;
+}

--- a/src/widgets/file-share-modal/FileShareModal.template.ts
+++ b/src/widgets/file-share-modal/FileShareModal.template.ts
@@ -1,0 +1,151 @@
+import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+
+/**
+ * Одна запись приглашённого пользователя в UI модалки файла.
+ */
+interface FileCollaborator {
+    /** ID пользователя */
+    id: number;
+    /** Видимая подпись (email или fallback) */
+    label: string;
+    /** Уровень доступа: 'view' / 'download' */
+    permission_level: string;
+}
+
+/**
+ * Рендерит select уровня доступа для одного приглашённого.
+ * @param userId - ID пользователя (попадёт в data-user-id)
+ * @param currentLevel - текущий уровень
+ * @returns HTML-разметка select'а
+ */
+function levelSelect(userId: string, currentLevel: string): string {
+    const view = currentLevel === 'view' ? 'selected' : '';
+    const dl = currentLevel === 'download' ? 'selected' : '';
+    return `<select class="file-share-modal__collaborator-level" data-user-id="${userId}" title="Уровень доступа">
+            <option value="view" ${view}>Просмотр</option>
+            <option value="download" ${dl}>Скачивание</option>
+        </select>`;
+}
+
+/**
+ * Опции рендера модалки шаринга файла.
+ */
+export interface FileShareModalTemplateOptions {
+    /** Имя файла для заголовка */
+    filename: string;
+    /** Включён ли публичный доступ */
+    isPublic: boolean;
+    /** Полный URL публичной ссылки или null */
+    publicUrl: string | null;
+    /** Выбранный срок жизни: '24h' / '7d' / '30d' / 'forever' */
+    selectedLifetime: string;
+    /** Список приглашённых */
+    collaborators: FileCollaborator[];
+}
+
+/**
+ * Рендерит модалку настроек доступа к файлу: тоггл публичного доступа,
+ * выбор срока жизни ссылки, копирование URL, список приглашённых по email
+ * с возможностью менять уровень view/download, форма приглашения.
+ * @param options - данные для отображения
+ * @returns HTML-разметка для innerHTML
+ */
+export function FileShareModalTemplate(options: FileShareModalTemplateOptions): string {
+    const { filename, isPublic, publicUrl, selectedLifetime, collaborators } = options;
+
+    const collaboratorItems = collaborators
+        .map(
+            (c) => `
+        <div class="file-share-modal__collaborator" data-user-id="${escapeHtml(String(c.id))}">
+            <span class="file-share-modal__collaborator-email">${escapeHtml(c.label)}</span>
+            ${levelSelect(escapeHtml(String(c.id)), c.permission_level)}
+            <button class="file-share-modal__remove-btn" title="Убрать доступ" data-user-id="${escapeHtml(String(c.id))}">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+            </button>
+        </div>`
+        )
+        .join('');
+
+    const lifetimes: { value: string; label: string }[] = [
+        { value: '24h', label: '24 часа' },
+        { value: '7d', label: '7 дней' },
+        { value: '30d', label: '30 дней' },
+        { value: 'forever', label: 'Без ограничений' }
+    ];
+    const lifetimeRadios = lifetimes
+        .map(
+            (l) =>
+                `<label class="file-share-modal__lifetime-option">
+                    <input type="radio" name="file-share-lifetime" value="${l.value}" ${l.value === selectedLifetime ? 'checked' : ''} />
+                    <span>${l.label}</span>
+                </label>`
+        )
+        .join('');
+
+    const linkValue = publicUrl ?? '';
+    const linkDisabled = isPublic ? '' : 'disabled';
+
+    return `<div class="file-share-modal__overlay">
+    <div class="file-share-modal" role="dialog" aria-modal="true" aria-label="Настройки доступа к файлу">
+        <div class="file-share-modal__header">
+            <h3 class="file-share-modal__title">Поделиться файлом «${escapeHtml(filename)}»</h3>
+            <button class="file-share-modal__close-btn" title="Закрыть">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+            </button>
+        </div>
+        <div class="file-share-modal__body">
+            <div class="file-share-modal__section file-share-modal__section--public">
+                <div class="file-share-modal__public-row">
+                    <div class="file-share-modal__public-info">
+                        <span class="file-share-modal__public-label">Публичная ссылка</span>
+                        <span class="file-share-modal__public-hint">Любой с этой ссылкой сможет скачать</span>
+                    </div>
+                    <label class="file-share-modal__toggle">
+                        <input class="file-share-modal__toggle-input" type="checkbox" ${isPublic ? 'checked' : ''} />
+                        <span class="file-share-modal__toggle-track">
+                            <span class="file-share-modal__toggle-thumb"></span>
+                        </span>
+                    </label>
+                </div>
+                <div class="file-share-modal__lifetime" ${isPublic ? '' : 'hidden'}>
+                    <span class="file-share-modal__lifetime-label">Срок действия</span>
+                    <div class="file-share-modal__lifetime-options">${lifetimeRadios}</div>
+                </div>
+                <div class="file-share-modal__link-row" ${isPublic ? '' : 'hidden'}>
+                    <input class="file-share-modal__link-input" type="text" readonly value="${escapeHtml(linkValue)}" ${linkDisabled} />
+                    <button class="file-share-modal__copy-btn" ${linkDisabled}>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                            <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                        </svg>
+                        Скопировать
+                    </button>
+                </div>
+            </div>
+            <div class="file-share-modal__section">
+                <label class="file-share-modal__label">Пригласить пользователя по email</label>
+                <div class="file-share-modal__input-row">
+                    <input class="file-share-modal__input" type="email" placeholder="example@mail.com" autocomplete="off" />
+                    <select class="file-share-modal__level-select" title="Уровень доступа">
+                        <option value="download">Скачивание</option>
+                        <option value="view">Просмотр</option>
+                    </select>
+                    <button class="file-share-modal__add-btn">Добавить</button>
+                </div>
+                <div class="file-share-modal__error" hidden></div>
+            </div>
+            <div class="file-share-modal__section file-share-modal__section--list">
+                ${
+                    collaborators.length > 0
+                        ? `<div class="file-share-modal__collaborators">${collaboratorItems}</div>`
+                        : `<p class="file-share-modal__empty">Нет пользователей с доступом</p>`
+                }
+            </div>
+        </div>
+    </div>
+</div>`;
+}

--- a/src/widgets/file-share-modal/FileShareModal.ts
+++ b/src/widgets/file-share-modal/FileShareModal.ts
@@ -1,0 +1,514 @@
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import { StorageApi } from '../../shared/api/StorageApi.js';
+import { logError } from '../../shared/utils/logger.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { FileShareModalTemplate } from './FileShareModal.template.js';
+import type { FileItemDTO, FileShareDTO } from '../../shared/api/types.js';
+
+/**
+ * Локальное представление одного приглашённого пользователя в UI модалки.
+ */
+interface FileCollaborator {
+    /** ID пользователя */
+    id: number;
+    /** Видимая подпись (email или fallback) */
+    label: string;
+    /** Уровень доступа: 'view' / 'download' */
+    permission_level: string;
+}
+
+/**
+ * Модалка управления доступом к файлу. По образцу ShareModal для notebook'ов,
+ * но с учётом особенностей файлов: уровни view/download (вместо readonly/editor),
+ * отдельный тоггл публичной ссылки с выбором срока жизни (24ч/7д/30д/без),
+ * копирование сгенерированного публичного URL.
+ *
+ * Singleton-подход: один экземпляр для всего приложения, маунтится по требованию
+ * через open(file). По close() — размонтируется и разблокирует scroll.
+ */
+export class FileShareModal extends BaseComponent {
+    static #instance: FileShareModal | null = null;
+    #file: FileItemDTO | null = null;
+    #storage: StorageApi;
+    #collaborators: FileCollaborator[] = [];
+    #lifetime = '7d';
+
+    /**
+     * Создаёт singleton (через getInstance). Element создаётся только при open.
+     */
+    public constructor() {
+        super(null, document.body);
+        this.#storage = StorageApi.getInstance();
+    }
+
+    /**
+     * Возвращает singleton-экземпляр.
+     * @returns единственный экземпляр FileShareModal
+     */
+    public static getInstance(): FileShareModal {
+        FileShareModal.#instance ??= new FileShareModal();
+        return FileShareModal.#instance;
+    }
+
+    /**
+     * Открывает модалку для конкретного файла: подтягивает список приглашённых,
+     * собирает DOM из шаблона, навешивает обработчики, блокирует scroll body.
+     * @param file - DTO файла, для которого настраиваем доступ
+     */
+    public async open(file: FileItemDTO): Promise<void> {
+        this.#file = file;
+        this.#collaborators = [];
+        this.#lifetime =
+            file.share_expires_at !== null &&
+            file.share_expires_at !== undefined &&
+            file.share_expires_at !== ''
+                ? this.#guessLifetime(file.share_expires_at)
+                : '7d';
+
+        await this.#fetchShares();
+        this.#buildElement();
+        super.mount();
+        document.body.style.overflow = 'hidden';
+        this._element.querySelector<HTMLInputElement>('.file-share-modal__input')?.focus();
+    }
+
+    /**
+     * Закрывает модалку и разблокирует scroll.
+     */
+    public close(): void {
+        if (!this._isMounted) return;
+        super.unmount();
+        document.body.style.overflow = '';
+    }
+
+    /**
+     * Переопределение базового mount: noop. Реальный монтаж делает open().
+     */
+    public override mount(): void {
+        /* noop */
+    }
+
+    /**
+     * Переопределение базового unmount: делегирует в close().
+     */
+    public override unmount(): void {
+        this.close();
+    }
+
+    /**
+     * Подтягивает текущий список приглашённых с бэка.
+     */
+    async #fetchShares(): Promise<void> {
+        if (!this.#file) return;
+        try {
+            const resp = await this.#storage.listShares(this.#file.id);
+            this.#collaborators = resp.shares.map((s) => ({
+                id: s.user_id,
+                label: s.email ?? `Пользователь #${String(s.user_id)}`,
+                permission_level: s.permission_level
+            }));
+        } catch (error) {
+            logError('FileShareModal.fetchShares failed', error);
+        }
+    }
+
+    /**
+     * Создаёт DOM-элемент из шаблона и навешивает обработчики.
+     */
+    #buildElement(): void {
+        const file = nn(this.#file);
+        const tmp = document.createElement('div');
+        tmp.innerHTML = FileShareModalTemplate({
+            filename: file.filename,
+            isPublic: file.is_public,
+            publicUrl: this.#buildPublicUrl(file.public_url ?? null),
+            selectedLifetime: this.#lifetime,
+            collaborators: this.#collaborators
+        });
+        this._element = tmp.firstElementChild as HTMLElement;
+        this.#attachEvents();
+    }
+
+    /**
+     * Собирает абсолютный URL публичной ссылки на основе относительного, который
+     * возвращает бэк. Если относительный путь пуст — null.
+     * @param relative - относительный URL вида /api/v1/shared/files/<token>
+     * @returns абсолютный URL или null
+     */
+    #buildPublicUrl(relative: string | null): string | null {
+        if (relative === null || relative === '') return null;
+        return `${window.location.origin}${relative}`;
+    }
+
+    /**
+     * Угадывает выбранный пользователем срок жизни ссылки по сохранённому
+     * share_expires_at. Если до истечения больше 28 дней — 30d, больше 5 — 7d,
+     * больше нескольких часов — 24h. Используется только при первичном
+     * открытии для предзаполнения radio'ов.
+     * @param expiresAt - ISO-строка срока истечения
+     * @returns ключ срока: '24h' / '7d' / '30d' / 'forever'
+     */
+    #guessLifetime(expiresAt: string): string {
+        const ms = new Date(expiresAt).getTime() - Date.now();
+        if (Number.isNaN(ms) || ms <= 0) return '7d';
+        const hours = ms / 3_600_000;
+        if (hours > 28 * 24) return '30d';
+        if (hours > 5 * 24) return '7d';
+        return '24h';
+    }
+
+    /**
+     * Конвертирует ключ срока в ISO-дату от текущего момента; 'forever' → null.
+     * @param key - выбранный ключ срока
+     * @returns ISO-строка или null
+     */
+    #lifetimeToISO(key: string): string | null {
+        const now = Date.now();
+        switch (key) {
+            case '24h':
+                return new Date(now + 24 * 3_600_000).toISOString();
+            case '7d':
+                return new Date(now + 7 * 24 * 3_600_000).toISOString();
+            case '30d':
+                return new Date(now + 30 * 24 * 3_600_000).toISOString();
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Навешивает обработчики событий на все интерактивные элементы.
+     */
+    #attachEvents(): void {
+        this._addListener(
+            this._element.querySelector('.file-share-modal__overlay'),
+            'click',
+            (e: Event) => {
+                if (e.target === e.currentTarget) this.close();
+            }
+        );
+        this._addListener(
+            this._element.querySelector('.file-share-modal__close-btn'),
+            'click',
+            () => {
+                this.close();
+            }
+        );
+        this._addListener(document, 'keydown', (e: Event) => {
+            if ((e as KeyboardEvent).key === 'Escape') this.close();
+        });
+
+        const toggle = nn(
+            this._element.querySelector<HTMLInputElement>('.file-share-modal__toggle-input')
+        );
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async event handler
+        this._addListener(toggle, 'change', () => this.#handlePublicToggle(toggle.checked));
+
+        const lifetimeRadios = this._element.querySelectorAll<HTMLInputElement>(
+            'input[name="file-share-lifetime"]'
+        );
+        lifetimeRadios.forEach((radio) => {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async event handler
+            this._addListener(radio, 'change', () => this.#handleLifetimeChange(radio.value));
+        });
+
+        this._addListener(
+            this._element.querySelector('.file-share-modal__copy-btn'),
+            'click',
+            () => {
+                this.#handleCopy();
+            }
+        );
+
+        const input = nn(this._element.querySelector<HTMLInputElement>('.file-share-modal__input'));
+        const levelSel = nn(
+            this._element.querySelector<HTMLSelectElement>('.file-share-modal__level-select')
+        );
+        const addBtn = nn(
+            this._element.querySelector<HTMLButtonElement>('.file-share-modal__add-btn')
+        );
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async event handler
+        this._addListener(addBtn, 'click', () => this.#handleAdd(input, levelSel));
+        this._addListener(input, 'keydown', (e: Event) => {
+            if ((e as KeyboardEvent).key === 'Enter') void this.#handleAdd(input, levelSel);
+        });
+
+        this.#attachListListeners();
+    }
+
+    /**
+     * Навешивает делегирование обработчиков на корневой контейнер списка
+     * приглашённых: клики (удаление) и change (смена уровня).
+     */
+    #attachListListeners(): void {
+        const list = this._element.querySelector('.file-share-modal__collaborators');
+        if (!list) return;
+        this._addListener(list, 'click', (e: Event) => {
+            const btn = (e.target as HTMLElement).closest<HTMLElement>(
+                '.file-share-modal__remove-btn'
+            );
+            if (btn?.dataset.userId !== undefined) {
+                void this.#handleRemove(btn.dataset.userId);
+            }
+        });
+        this._addListener(list, 'change', (e: Event) => {
+            const sel = (e.target as HTMLElement).closest<HTMLSelectElement>(
+                '.file-share-modal__collaborator-level'
+            );
+            if (sel?.dataset.userId !== undefined) {
+                void this.#handleLevelChange(sel.dataset.userId, sel.value);
+            }
+        });
+    }
+
+    /**
+     * Переключает публичный доступ. При включении использует выбранный срок
+     * через #lifetimeToISO; при выключении показывает confirm и обнуляет токен.
+     * При ошибке откатывает чекбокс.
+     * @param checked - новое состояние тогла
+     */
+    async #handlePublicToggle(checked: boolean): Promise<void> {
+        const file = nn(this.#file);
+        if (!checked) {
+            // eslint-disable-next-line no-alert -- TODO(ui): replace with confirmation modal
+            const ok = window.confirm(
+                'Отключить публичную ссылку? Текущая ссылка перестанет работать.'
+            );
+            if (!ok) {
+                const toggle = nn(
+                    this._element.querySelector<HTMLInputElement>('.file-share-modal__toggle-input')
+                );
+                toggle.checked = true;
+                return;
+            }
+        }
+        try {
+            const updated = await this.#storage.setPublic(
+                file.id,
+                checked,
+                checked ? this.#lifetimeToISO(this.#lifetime) : null
+            );
+            this.#file = updated;
+            this.#rerender();
+        } catch (error) {
+            logError('FileShareModal.setPublic failed', error);
+            const toggle = nn(
+                this._element.querySelector<HTMLInputElement>('.file-share-modal__toggle-input')
+            );
+            toggle.checked = !checked;
+        }
+    }
+
+    /**
+     * Меняет срок жизни уже выпущенной публичной ссылки. Тихо игнорирует
+     * ошибки сети, но в UI оставляет ранее выбранный radio (без отката, чтобы
+     * не мешать пользователю).
+     * @param key - новый ключ срока ('24h' / '7d' / '30d' / 'forever')
+     */
+    async #handleLifetimeChange(key: string): Promise<void> {
+        const file = nn(this.#file);
+        this.#lifetime = key;
+        if (!file.is_public) return;
+        try {
+            const updated = await this.#storage.setPublic(file.id, true, this.#lifetimeToISO(key));
+            this.#file = updated;
+        } catch (error) {
+            logError('FileShareModal.lifetimeChange failed', error);
+        }
+    }
+
+    /**
+     * Копирует публичный URL в буфер обмена и показывает кратковременный
+     * фидбек на кнопке.
+     */
+    #handleCopy(): void {
+        const input = this._element.querySelector<HTMLInputElement>(
+            '.file-share-modal__link-input'
+        );
+        if (input === null || input.value === '') return;
+        void navigator.clipboard.writeText(input.value).then(() => {
+            this.#showCopyFeedback();
+        });
+    }
+
+    /**
+     * Показывает «Скопировано!» на 2 секунды на кнопке копирования.
+     */
+    #showCopyFeedback(): void {
+        const btn = this._element.querySelector('.file-share-modal__copy-btn');
+        if (!btn) return;
+        const original = btn.innerHTML;
+        btn.textContent = 'Скопировано!';
+        btn.classList.add('file-share-modal__copy-btn--success');
+        setTimeout(() => {
+            btn.innerHTML = original;
+            btn.classList.remove('file-share-modal__copy-btn--success');
+        }, 2000);
+    }
+
+    /**
+     * Добавляет нового приглашённого. Валидирует email и не позволяет
+     * пригласить уже добавленного.
+     * @param input - input с email
+     * @param levelSel - select уровня
+     */
+    async #handleAdd(input: HTMLInputElement, levelSel: HTMLSelectElement): Promise<void> {
+        const file = nn(this.#file);
+        const email = input.value.trim();
+        if (!email) return;
+        if (!this.#isValidEmail(email)) {
+            this.#showError('Введите корректный email');
+            return;
+        }
+        if (this.#collaborators.some((c) => c.label.toLowerCase() === email.toLowerCase())) {
+            this.#showError('Пользователь уже имеет доступ');
+            return;
+        }
+        const level: 'view' | 'download' = levelSel.value === 'view' ? 'view' : 'download';
+        const addBtn = nn(
+            this._element.querySelector<HTMLButtonElement>('.file-share-modal__add-btn')
+        );
+        addBtn.disabled = true;
+        this.#clearError();
+        try {
+            const share: FileShareDTO = await this.#storage.shareFile(file.id, email, level);
+            this.#collaborators.push({
+                id: share.user_id,
+                label: share.email ?? email,
+                permission_level: share.permission_level
+            });
+            // eslint-disable-next-line require-atomic-updates -- DOM single-threaded; input captured locally
+            input.value = '';
+            this.#rerenderList();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : 'Не удалось добавить пользователя';
+            this.#showError(msg);
+        } finally {
+            addBtn.disabled = false;
+        }
+    }
+
+    /**
+     * Удаляет приглашение конкретного пользователя.
+     * @param userId - ID удаляемого пользователя (строкой из data-attribute)
+     */
+    async #handleRemove(userId: string): Promise<void> {
+        const file = nn(this.#file);
+        const id = Number(userId);
+        try {
+            await this.#storage.revokeShare(file.id, id);
+            this.#collaborators = this.#collaborators.filter((c) => c.id !== id);
+            this.#rerenderList();
+        } catch (error) {
+            logError('FileShareModal.remove failed', error);
+        }
+    }
+
+    /**
+     * Меняет уровень доступа существующего приглашённого. Optimistic:
+     * сразу обновляем локально, при ошибке откатываем select.
+     * @param userId - ID пользователя
+     * @param level - новый уровень ('view' / 'download')
+     */
+    async #handleLevelChange(userId: string, level: string): Promise<void> {
+        const file = nn(this.#file);
+        const collab = this.#collaborators.find((c) => String(c.id) === userId);
+        if (!collab) return;
+        const prev = collab.permission_level;
+        collab.permission_level = level;
+        const lvl: 'view' | 'download' = level === 'view' ? 'view' : 'download';
+        try {
+            await this.#storage.updateShare(file.id, collab.id, lvl);
+        } catch (error) {
+            logError('FileShareModal.levelChange failed', error);
+            collab.permission_level = prev;
+            this.#rerenderList();
+        }
+    }
+
+    /**
+     * Перерисовывает весь body модалки на основе текущего #file. Используется
+     * после смены public-state — там меняется и видимость секций.
+     */
+    #rerender(): void {
+        if (!this._element.parentNode) return;
+        const parent = this._element.parentNode;
+        const old = this._element;
+        this.#buildElement();
+        parent.replaceChild(this._element, old);
+    }
+
+    /**
+     * Перерисовывает только секцию списка приглашённых и заново навешивает
+     * слушатели на список.
+     */
+    #rerenderList(): void {
+        const section = this._element.querySelector('.file-share-modal__section--list');
+        if (!section) return;
+        if (this.#collaborators.length === 0) {
+            section.innerHTML =
+                '<p class="file-share-modal__empty">Нет пользователей с доступом</p>';
+            return;
+        }
+        const items = this.#collaborators
+            .map(
+                (c) => `
+            <div class="file-share-modal__collaborator" data-user-id="${String(c.id)}">
+                <span class="file-share-modal__collaborator-email">${this.#escape(c.label)}</span>
+                <select class="file-share-modal__collaborator-level" data-user-id="${String(c.id)}" title="Уровень доступа">
+                    <option value="view" ${c.permission_level === 'view' ? 'selected' : ''}>Просмотр</option>
+                    <option value="download" ${c.permission_level === 'download' ? 'selected' : ''}>Скачивание</option>
+                </select>
+                <button class="file-share-modal__remove-btn" title="Убрать доступ" data-user-id="${String(c.id)}">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                    </svg>
+                </button>
+            </div>`
+            )
+            .join('');
+        section.innerHTML = `<div class="file-share-modal__collaborators">${items}</div>`;
+        this.#attachListListeners();
+    }
+
+    /**
+     * Показывает сообщение об ошибке в блоке .file-share-modal__error.
+     * @param msg - текст ошибки
+     */
+    #showError(msg: string): void {
+        const el = this._element.querySelector<HTMLElement>('.file-share-modal__error');
+        if (!el) return;
+        el.textContent = msg;
+        el.hidden = false;
+    }
+
+    /**
+     * Скрывает блок ошибки.
+     */
+    #clearError(): void {
+        const el = this._element.querySelector<HTMLElement>('.file-share-modal__error');
+        if (el) el.hidden = true;
+    }
+
+    /**
+     * Проверяет email на минимальный формат.
+     * @param email - проверяемая строка
+     * @returns true если похоже на email
+     */
+    #isValidEmail(email: string): boolean {
+        return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    }
+
+    /**
+     * Экранирует HTML-спецсимволы для безопасной вставки в innerHTML.
+     * @param str - строка для эскейпа
+     * @returns HTML-безопасная строка
+     */
+    #escape(str: string): string {
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+}

--- a/src/widgets/rename-modal/RenameModal.scss
+++ b/src/widgets/rename-modal/RenameModal.scss
@@ -1,0 +1,106 @@
+.rename-modal__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+}
+
+.rename-modal {
+    width: 100%;
+    max-width: 420px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.16);
+    overflow: hidden;
+}
+
+.rename-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    border-bottom: 1px solid #eef3ee;
+}
+
+.rename-modal__title {
+    margin: 0;
+    font-size: 15px;
+    color: #2e3a2f;
+}
+
+.rename-modal__close-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #5a6a5c;
+    padding: 4px;
+    line-height: 0;
+}
+
+.rename-modal__body {
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.rename-modal__label {
+    font-size: 12px;
+    color: #5a6a5c;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.rename-modal__input {
+    padding: 8px 10px;
+    border: 1px solid #d6e2d8;
+    border-radius: 6px;
+    font-size: 14px;
+    color: #2e3a2f;
+    outline: none;
+}
+
+.rename-modal__input:focus {
+    border-color: #6abf73;
+}
+
+.rename-modal__error {
+    color: #b03a2e;
+    font-size: 12px;
+}
+
+.rename-modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid #eef3ee;
+    background: #f8fbf8;
+}
+
+.rename-modal__cancel-btn,
+.rename-modal__save-btn {
+    padding: 8px 14px;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.rename-modal__cancel-btn {
+    background: #eef3ee;
+    color: #2e3a2f;
+}
+
+.rename-modal__save-btn {
+    background: #2e7233;
+    color: #fff;
+}
+
+.rename-modal__save-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/src/widgets/rename-modal/RenameModal.template.ts
+++ b/src/widgets/rename-modal/RenameModal.template.ts
@@ -1,0 +1,31 @@
+import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+
+/**
+ * Рендерит модалку переименования файла с предзаполненным значением.
+ * @param currentName - текущее имя файла
+ * @returns HTML-разметка
+ */
+export function RenameModalTemplate(currentName: string): string {
+    return `<div class="rename-modal__overlay">
+    <div class="rename-modal" role="dialog" aria-modal="true" aria-label="Переименование файла">
+        <div class="rename-modal__header">
+            <h3 class="rename-modal__title">Переименовать файл</h3>
+            <button class="rename-modal__close-btn" title="Закрыть">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+            </button>
+        </div>
+        <div class="rename-modal__body">
+            <label class="rename-modal__label" for="rename-modal-input">Новое имя</label>
+            <input id="rename-modal-input" class="rename-modal__input" type="text"
+                value="${escapeHtml(currentName)}" maxlength="255" />
+            <div class="rename-modal__error" hidden></div>
+        </div>
+        <div class="rename-modal__footer">
+            <button class="rename-modal__cancel-btn">Отмена</button>
+            <button class="rename-modal__save-btn">Сохранить</button>
+        </div>
+    </div>
+</div>`;
+}

--- a/src/widgets/rename-modal/RenameModal.ts
+++ b/src/widgets/rename-modal/RenameModal.ts
@@ -1,0 +1,160 @@
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import { StorageApi } from '../../shared/api/StorageApi.js';
+import { logError } from '../../shared/utils/logger.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { RenameModalTemplate } from './RenameModal.template.js';
+import type { FileItemDTO } from '../../shared/api/types.js';
+
+/**
+ * Singleton-модалка переименования файла. Открывается одним методом open(file),
+ * принимает новое имя из инпута, валидирует и вызывает StorageApi.renameFile.
+ * При успехе вызывает onSave-коллбек (для обновления родительской таблицы).
+ */
+export class RenameModal extends BaseComponent {
+    static #instance: RenameModal | null = null;
+    #file: FileItemDTO | null = null;
+    #storage: StorageApi;
+    #onSave: ((file: FileItemDTO) => void) | null = null;
+
+    /**
+     * Создаёт singleton (через getInstance).
+     */
+    public constructor() {
+        super(null, document.body);
+        this.#storage = StorageApi.getInstance();
+    }
+
+    /**
+     * Возвращает singleton-экземпляр.
+     * @returns единственный экземпляр RenameModal
+     */
+    public static getInstance(): RenameModal {
+        RenameModal.#instance ??= new RenameModal();
+        return RenameModal.#instance;
+    }
+
+    /**
+     * Открывает модалку: рендерит UI, маунтит, фокусирует input.
+     * @param file - DTO файла для переименования
+     * @param onSave - коллбек с обновлённым DTO после успешного rename
+     */
+    public open(file: FileItemDTO, onSave: (file: FileItemDTO) => void): void {
+        this.#file = file;
+        this.#onSave = onSave;
+        const tmp = document.createElement('div');
+        tmp.innerHTML = RenameModalTemplate(file.filename);
+        this._element = tmp.firstElementChild as HTMLElement;
+        this.#attachEvents();
+        super.mount();
+        document.body.style.overflow = 'hidden';
+        const input = nn(this._element.querySelector<HTMLInputElement>('.rename-modal__input'));
+        input.focus();
+        input.select();
+    }
+
+    /**
+     * Закрывает модалку и разблокирует scroll.
+     */
+    public close(): void {
+        if (!this._isMounted) return;
+        super.unmount();
+        document.body.style.overflow = '';
+    }
+
+    /**
+     * Переопределение базового mount: noop. Реальный монтаж делается из open().
+     */
+    public override mount(): void {
+        /* noop */
+    }
+
+    /**
+     * Переопределение базового unmount: делегирует в close().
+     */
+    public override unmount(): void {
+        this.close();
+    }
+
+    /**
+     * Навешивает обработчики: закрытие (overlay/Escape/X/Cancel), сохранение
+     * (Enter/Save).
+     */
+    #attachEvents(): void {
+        this._addListener(
+            this._element.querySelector('.rename-modal__overlay'),
+            'click',
+            (e: Event) => {
+                if (e.target === e.currentTarget) this.close();
+            }
+        );
+        this._addListener(this._element.querySelector('.rename-modal__close-btn'), 'click', () => {
+            this.close();
+        });
+        this._addListener(this._element.querySelector('.rename-modal__cancel-btn'), 'click', () => {
+            this.close();
+        });
+        this._addListener(document, 'keydown', (e: Event) => {
+            if ((e as KeyboardEvent).key === 'Escape') this.close();
+        });
+
+        const input = nn(this._element.querySelector<HTMLInputElement>('.rename-modal__input'));
+        const saveBtn = nn(
+            this._element.querySelector<HTMLButtonElement>('.rename-modal__save-btn')
+        );
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async event handler
+        this._addListener(saveBtn, 'click', () => this.#handleSave(input.value));
+        this._addListener(input, 'keydown', (e: Event) => {
+            if ((e as KeyboardEvent).key === 'Enter') void this.#handleSave(input.value);
+        });
+    }
+
+    /**
+     * Валидирует имя и сохраняет на бэк. При ошибке показывает текст.
+     * @param raw - значение из input
+     */
+    async #handleSave(raw: string): Promise<void> {
+        const file = nn(this.#file);
+        const name = raw.trim();
+        if (!name) {
+            this.#showError('Имя не может быть пустым');
+            return;
+        }
+        if (name.length > 255) {
+            this.#showError('Имя слишком длинное (максимум 255)');
+            return;
+        }
+        if (/[/\\]/.test(name)) {
+            this.#showError('Имя не должно содержать символы / и \\');
+            return;
+        }
+        if (name === file.filename) {
+            this.close();
+            return;
+        }
+        const saveBtn = nn(
+            this._element.querySelector<HTMLButtonElement>('.rename-modal__save-btn')
+        );
+        saveBtn.disabled = true;
+        try {
+            const updated = await this.#storage.renameFile(file.id, name);
+            this.#onSave?.(updated);
+            this.close();
+        } catch (error) {
+            logError('RenameModal.save failed', error);
+            const msg = error instanceof Error ? error.message : 'Не удалось переименовать';
+            this.#showError(msg);
+            saveBtn.disabled = false;
+        }
+    }
+
+    /**
+     * Показывает текст ошибки.
+     * @param msg - сообщение
+     */
+    #showError(msg: string): void {
+        const el = this._element.querySelector<HTMLElement>('.rename-modal__error');
+        if (!el) return;
+        el.textContent = msg;
+        el.hidden = false;
+    }
+}

--- a/src/widgets/stats-section/StatsSection.template.ts
+++ b/src/widgets/stats-section/StatsSection.template.ts
@@ -55,6 +55,7 @@ export function StatsSectionTemplate(): string {
 
     <div class="stats-section__storage">
         <div class="stats-section__storage-title">Хранилище</div>
+        <div class="stats-section__disk-usage-mount"></div>
         <div class="stats-section__storage-cards"></div>
     </div>
 </div>`;

--- a/src/widgets/stats-section/StatsSection.ts
+++ b/src/widgets/stats-section/StatsSection.ts
@@ -47,6 +47,7 @@ export class StatsSection extends BaseComponent {
         );
         if (diskMount) {
             this.#diskUsage = new DiskUsageCard(diskMount, {
+                compact: true,
                 onClick: (): void => {
                     nn(Router.getInstance()).navigate('/disk');
                 }

--- a/src/widgets/stats-section/StatsSection.ts
+++ b/src/widgets/stats-section/StatsSection.ts
@@ -2,6 +2,8 @@ import { BaseComponent } from '../../shared/components/base-component/BaseCompon
 import { StatsApi, type UserStats } from '../../shared/api/StatsApi.js';
 import { renderBarChart, fillDays } from '../../shared/utils/chart.js';
 import { StatsSectionTemplate } from './StatsSection.template.js';
+import { DiskUsageCard } from '../disk-usage-card/DiskUsageCard.js';
+import { Router } from '../../shared/router/Router.js';
 import { nn } from '../../shared/utils/notNull.js';
 
 /**
@@ -14,6 +16,7 @@ import { nn } from '../../shared/utils/notNull.js';
  */
 export class StatsSection extends BaseComponent {
     #api: StatsApi;
+    #diskUsage: DiskUsageCard | null = null;
 
     /**
      * Создаёт и рендерит секцию. Загрузка данных откладывается до mount.
@@ -39,7 +42,27 @@ export class StatsSection extends BaseComponent {
      */
     public mount(): void {
         super.mount();
+        const diskMount = this._element.querySelector<HTMLElement>(
+            '.stats-section__disk-usage-mount'
+        );
+        if (diskMount) {
+            this.#diskUsage = new DiskUsageCard(diskMount, {
+                onClick: (): void => {
+                    nn(Router.getInstance()).navigate('/disk');
+                }
+            });
+            this.#diskUsage.mount();
+        }
         void this.#loadStats();
+    }
+
+    /**
+     * Размонтирует секцию и встроенную карточку диска.
+     */
+    public override unmount(): void {
+        this.#diskUsage?.unmount();
+        this.#diskUsage = null;
+        super.unmount();
     }
 
     /**

--- a/src/widgets/stats-section/StatsSection.ts
+++ b/src/widgets/stats-section/StatsSection.ts
@@ -48,6 +48,7 @@ export class StatsSection extends BaseComponent {
         if (diskMount) {
             this.#diskUsage = new DiskUsageCard(diskMount, {
                 compact: true,
+                inset: true,
                 onClick: (): void => {
                     nn(Router.getInstance()).navigate('/disk');
                 }

--- a/src/widgets/stats-section/StatsSection.ts
+++ b/src/widgets/stats-section/StatsSection.ts
@@ -48,7 +48,6 @@ export class StatsSection extends BaseComponent {
         if (diskMount) {
             this.#diskUsage = new DiskUsageCard(diskMount, {
                 compact: true,
-                inset: true,
                 onClick: (): void => {
                     nn(Router.getInstance()).navigate('/disk');
                 }


### PR DESCRIPTION
## Что сделано

### Слой 1 — диск, drag-and-drop, статистика (предыдущий этап)

- Добавлен маршрут `/disk` со страницей «Мой диск»: drag-and-drop зона `FileDropZone`, таблица файлов `DiskTable`, пагинация, карточка заполненности.
- Виджет `DiskUsageCard` показывает прогресс-бар занятого места, бейдж тарифа и количество файлов; цвет шкалы меняется при 70% и 90%. Карточка встроена в секцию статистики профиля и над списком ноутбуков на `/files`, клик ведёт на `/disk`.
- В админ-панель добавлена секция «Файлы» (`AdminFilesSection`) с фильтрами по категории и `owner_id`, пагинацией и кнопкой удалить.
- Добавлен `StorageApi` (singleton) поверх `HttpClient` с методами `uploadFile`, `listFiles`, `deleteFile`, `getUsage`, `adminListFiles` и DTO в `shared/api/types.ts`. Утилита `formatBytes`.

### Слой 2 — sharing файлов (этот слой)

- `FileItemDTO` расширен полями `is_public`, `share_token`, `share_expires_at`, `downloads_count`, `your_permission`, `download_url`, `public_url`. Добавлены `FileShareDTO` и `FileShareListResponse`.
- `StorageApi` пополнен методами `shareFile`, `listShares`, `updateShare`, `revokeShare`, `setPublic` (с опциональным `expiresAt` ISO), `renameFile`, `listSharedWithMe`.
- Виджет `FileShareModal`: тоггл публичной ссылки с выбором срока жизни (24ч / 7д / 30д / без ограничений), копирование сгенерированного URL, форма приглашения по email с уровнем `view` / `download`, список приглашённых с change-уровня и кнопкой убрать. При выключении публичности — confirm-предупреждение, что ссылка перестанет работать.
- Виджет `RenameModal`: input с предзаполненным именем, валидация длины 1..255 и запрета `/` и `\`, сохранение через `StorageApi.renameFile`.
- `DiskTable` расширен: действия «Скачать» (на download endpoint), «Поделиться», «Переименовать», «Удалить»; колонка «Скачиваний» (показывается только при счётчике >0); бейдж «Публичный» рядом с именем; режим `shared` (вкладка «расшарено со мной») показывает только «Скачать» или disabled-подсказку «Только просмотр» при уровне `view`.
- `DiskPage`: переключатель табов «Мои файлы» / «Расшарено со мной», второй DiskTable + пагинация для расшаренного списка, проводка модалок Share/Rename, рефреш списка после действий.
- Новая страница `/shared/files/:token` (`SharedFilePage`, без auth-guard'а): по HEAD-запросу на download endpoint достаёт filename/size/MIME, показывает карточку с кнопкой «Скачать»; 410 → «Срок действия ссылки истёк», 404 → «Файл не найден».
- ESLint / Prettier / TypeScript проходят без замечаний; полный фронт-билд собирается.

<img width="1003" height="657" alt="Снимок экрана 2026-05-14 в 12 32 09" src="https://github.com/user-attachments/assets/e1980e4e-c461-43ee-81b0-73c1babebffd" />
<img width="990" height="424" alt="Снимок экрана 2026-05-14 в 12 32 18" src="https://github.com/user-attachments/assets/606cff0c-c270-4726-b57e-191c5b20f9cd" />
<img width="748" height="231" alt="Снимок экрана 2026-05-14 в 12 32 31" src="https://github.com/user-attachments/assets/14c31a9c-65ca-4b01-8592-a753ccc943b3" />
