### PR TITLE
feat(ui): чат с ИИ в боковой панели ноутбука

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -28,11 +28,13 @@
 @use '../widgets/notebook-header/NotebookHeader';
 @use '../widgets/notebook-toolbar/NotebookToolbar';
 @use '../widgets/notebook-sidebar/NotebookSidebar';
+@use '../widgets/ai-chat-panel/AiChatPanel';
 @use '../widgets/cell-list/CellList';
 @use '../widgets/profile-section/ProfileSection';
 @use '../widgets/password-section/PasswordSection';
 @use '../widgets/subscription-section/SubscriptionSection';
 @use '../widgets/editor-settings/EditorSettings';
+@use '../widgets/ai-settings/AiSettings';
 @use '../widgets/feedback-modal/FeedbackModal';
 @use '../widgets/stats-section/StatsSection';
 @use '../widgets/container-stats/ContainerStats';

--- a/src/pages/blocks/BlocksPage.ts
+++ b/src/pages/blocks/BlocksPage.ts
@@ -7,6 +7,7 @@ import {
     type SearchMatch,
     type SearchableCellSnapshot
 } from '../../widgets/notebook-sidebar/NotebookSidebar.js';
+import { AiChatPanel } from '../../widgets/ai-chat-panel/AiChatPanel.js';
 import { CellList } from '../../widgets/cell-list/CellList.js';
 import { CodeCell } from '../../shared/components/code-cell/CodeCell.js';
 import { TextCell } from '../../shared/components/text-cell/TextCell.js';
@@ -273,7 +274,11 @@ export class BlocksPage {
 
         this.#sidebar = new NotebookSidebar(sidebarArea, {
             searchTarget: this.#buildSearchAdapter(),
-            notebookId: this.#notebookId
+            notebookId: this.#notebookId,
+            mountAiChat: (container: HTMLElement): void => {
+                const panel = new AiChatPanel(container, Number(this.#notebookId));
+                panel.mount();
+            }
         });
         this.#sidebar.mount();
 

--- a/src/pages/profile/ProfilePage.template.ts
+++ b/src/pages/profile/ProfilePage.template.ts
@@ -18,6 +18,7 @@ export function ProfilePageTemplate(): string {
             <div class="profile-page__sidebar-group">
                 <h3 class="profile-page__sidebar-title">Настройки</h3>
                 <button class="profile-page__sidebar-item" data-section="editor">Оформление</button>
+                <button class="profile-page__sidebar-item" data-section="ai">ИИ</button>
             </div>
         </nav>
         <div class="profile-page__content"></div>

--- a/src/pages/profile/ProfilePage.ts
+++ b/src/pages/profile/ProfilePage.ts
@@ -4,6 +4,7 @@ import { PasswordSection } from '../../widgets/password-section/PasswordSection.
 import { SubscriptionSection } from '../../widgets/subscription-section/SubscriptionSection.js';
 import { EditorSettings } from '../../widgets/editor-settings/EditorSettings.js';
 import { StatsSection } from '../../widgets/stats-section/StatsSection.js';
+import { AiSettings } from '../../widgets/ai-settings/AiSettings.js';
 import { HttpClient } from '../../shared/http_client/HttpClient.js';
 import { Router } from '../../shared/router/Router.js';
 import { ProfilePageTemplate } from './ProfilePage.template.js';
@@ -33,7 +34,8 @@ const SECTION_MAP: Record<string, new (...args: any[]) => MountableSection> = {
     password: PasswordSection,
     subscription: SubscriptionSection,
     stats: StatsSection,
-    editor: EditorSettings
+    editor: EditorSettings,
+    ai: AiSettings
 };
 
 /**

--- a/src/shared/api/AiApi.ts
+++ b/src/shared/api/AiApi.ts
@@ -1,0 +1,108 @@
+import { HttpClient } from '../http_client/HttpClient.js';
+import type {
+    AiModelsResponse,
+    ChatHistoryResponse,
+    ChatSettingsDTO,
+    ChatUsageResponse
+} from './chatTypes.js';
+import type { ApiEnvelope } from './types.js';
+
+/**
+ * REST-клиент для AI-чата: история переписки в ноутбуке, пользовательские
+ * настройки (модель + системный промпт), статистика использования и список
+ * доступных моделей с учётом тарифа. WS-стриминг сообщений — в ChatWS.
+ *
+ * Бэкенд: cmd/chat за gateway, эндпоинты `/api/v1/chat/*`.
+ */
+export class AiApi {
+    #http: HttpClient;
+
+    /**
+     * Получает singleton HttpClient: shared cookie-сессия и CSRF-токен.
+     */
+    public constructor() {
+        this.#http = HttpClient.getInstance();
+    }
+
+    /**
+     * Парсит JSON-ответ, проверяет ApiEnvelope и бросает Error при не-2xx.
+     * @param response - объект Response от fetch
+     * @returns распакованный body.data типа T
+     * @throws Error с серверным error или 'HTTP <status>' если тело пустое
+     */
+    async #parse<T>(response: Response): Promise<T> {
+        const body = (await response.json().catch(() => ({}))) as Partial<ApiEnvelope<T>>;
+        if (!response.ok) {
+            throw new Error(body.error ?? `HTTP ${String(response.status)}`);
+        }
+        return body.data as T;
+    }
+
+    /**
+     * Возвращает историю переписки по ноутбуку в хронологическом порядке.
+     * @param notebookId - ID ноутбука
+     * @param limit - максимум сообщений (по умолчанию 200 на бэке)
+     * @returns массив сообщений
+     */
+    public async getHistory(notebookId: number, limit?: number): Promise<ChatHistoryResponse> {
+        const qs = limit !== undefined && limit > 0 ? `&limit=${String(limit)}` : '';
+        const r = await this.#http.get(`/chat/history?notebook_id=${String(notebookId)}${qs}`, {
+            noCache: true
+        });
+        return this.#parse<ChatHistoryResponse>(r);
+    }
+
+    /**
+     * Очищает историю чата для конкретного ноутбука. Возвращает 204 без тела.
+     * @param notebookId - ID ноутбука
+     */
+    public async clearHistory(notebookId: number): Promise<void> {
+        const r = await this.#http.delete(`/chat/history?notebook_id=${String(notebookId)}`);
+        if (!r.ok) throw new Error(`HTTP ${String(r.status)}`);
+    }
+
+    /**
+     * Загружает пользовательские настройки чата с ИИ (модель + системный промпт).
+     * Если настроек ещё нет — сервер вернёт дефолты для текущего тарифа.
+     * @returns снимок настроек
+     */
+    public async getSettings(): Promise<ChatSettingsDTO> {
+        const r = await this.#http.get('/chat/settings', { noCache: true });
+        return this.#parse<ChatSettingsDTO>(r);
+    }
+
+    /**
+     * Обновляет настройки чата. Модель должна быть в whitelist текущего тарифа,
+     * иначе бэкенд вернёт 403.
+     * @param model - идентификатор модели
+     * @param systemPrompt - системный промпт (не более 8000 символов)
+     * @returns обновлённый снимок настроек
+     */
+    public async updateSettings(model: string, systemPrompt: string): Promise<ChatSettingsDTO> {
+        const r = await this.#http.put('/chat/settings', {
+            model,
+            system_prompt: systemPrompt
+        });
+        return this.#parse<ChatSettingsDTO>(r);
+    }
+
+    /**
+     * Возвращает статистику использования: расход за сегодня, лимиты тарифа,
+     * общие итоги и разбивку по моделям.
+     * @returns снимок использования
+     */
+    public async getUsage(): Promise<ChatUsageResponse> {
+        const r = await this.#http.get('/chat/usage', { noCache: true });
+        return this.#parse<ChatUsageResponse>(r);
+    }
+
+    /**
+     * Возвращает список всех известных моделей с пометкой доступности
+     * для текущего пользователя (в зависимости от его тарифа).
+     * @returns список моделей
+     */
+    public async getModels(): Promise<AiModelsResponse> {
+        const r = await this.#http.get('/chat/models', { noCache: true });
+        return this.#parse<AiModelsResponse>(r);
+    }
+}

--- a/src/shared/api/ChatWS.ts
+++ b/src/shared/api/ChatWS.ts
@@ -1,0 +1,206 @@
+import { nn } from '../utils/notNull.js';
+import type { ChatContextOptions, ChatWSIncoming } from './chatTypes.js';
+
+/**
+ * WebSocket-клиент для AI-чата. Подключается к ws(s)://host/api/v1/chat/ws,
+ * шлёт пользовательские сообщения и принимает поток чанков ответа модели
+ * с типизированными событиями (chunk / done / error).
+ *
+ * Особенности:
+ * - **Авто-reconnect** с экспоненциальным backoff (1s → 2s → 4s → 8s → 15s).
+ * - **Ping/pong** каждые 25 секунд для keepalive — gateway закрывает idle.
+ * - **Коды 4400–4499** считаются permanent (forbidden, freeze-план) и не
+ *   вызывают reconnect.
+ * - **closedByUser** — флаг ручного close() чтобы не зацикливать reconnect.
+ *
+ * В отличие от NotebookWS, здесь нет привязки к notebookId на уровне URL —
+ * сессия открыта один раз для пользователя, а notebook_id передаётся внутри
+ * каждого сообщения.
+ */
+export class ChatWS {
+    #socket: WebSocket | null = null;
+    #pingTimer: ReturnType<typeof setInterval> | null = null;
+    #reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    #reconnectAttempt = 0;
+    #closedByUser = false;
+    #onMessage: (event: ChatWSIncoming) => void;
+    #onConnect: (() => void) | null;
+    #onClose: ((code: number) => void) | null;
+
+    /**
+     * Создаёт клиент. Соединение НЕ открывается — нужен явный вызов connect().
+     * @param callbacks - обработчики событий (onMessage обязателен по смыслу)
+     */
+    public constructor({
+        onMessage,
+        onConnect,
+        onClose
+    }: {
+        onMessage?: (event: ChatWSIncoming) => void;
+        onConnect?: () => void;
+        onClose?: (code: number) => void;
+    } = {}) {
+        this.#onMessage =
+            onMessage ??
+            ((): void => {
+                /* noop */
+            });
+        this.#onConnect = onConnect ?? null;
+        this.#onClose = onClose ?? null;
+    }
+
+    /**
+     * Открывает WebSocket-соединение и сбрасывает closedByUser, чтобы
+     * reconnect работал при последующих обрывах.
+     */
+    public connect(): void {
+        this.#closedByUser = false;
+        this.#open();
+    }
+
+    /**
+     * Финально закрывает соединение, останавливает таймеры и блокирует
+     * автоматический reconnect.
+     */
+    public close(): void {
+        this.#closedByUser = true;
+        if (this.#reconnectTimer !== null) {
+            clearTimeout(this.#reconnectTimer);
+            this.#reconnectTimer = null;
+        }
+        this.#stopPing();
+        if (this.#socket) {
+            try {
+                this.#socket.close(1000, 'client closed');
+            } catch {
+                /* ignore */
+            }
+            this.#socket = null;
+        }
+    }
+
+    /**
+     * Отправляет пользовательское сообщение в чат. Ответ придёт серией
+     * `chunk`-событий, завершающим `done` и опционально `error`.
+     * @param notebookId - ID ноутбука для привязки истории
+     * @param content - текст сообщения
+     * @param model - идентификатор модели (пусто — серверный default)
+     * @param context - дополнительный контекст (ячейка/ноутбук)
+     * @returns true если send удался, false при закрытом сокете
+     */
+    public sendMessage(
+        notebookId: number,
+        content: string,
+        model?: string,
+        context?: ChatContextOptions
+    ): boolean {
+        return this.#send({
+            type: 'message',
+            notebook_id: notebookId,
+            content,
+            model,
+            context
+        });
+    }
+
+    /**
+     * Проверяет состояние соединения.
+     * @returns true если WebSocket в состоянии OPEN
+     */
+    public isOpen(): boolean {
+        return this.#socket !== null && this.#socket.readyState === WebSocket.OPEN;
+    }
+
+    /**
+     * Внутренний метод открытия соединения. Регистрирует обработчики
+     * open/message/close/error, стартует ping-таймер при open.
+     */
+    #open(): void {
+        const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const url = `${proto}//${window.location.host}/api/v1/chat/ws`;
+        let socket: WebSocket;
+        try {
+            socket = new WebSocket(url);
+        } catch {
+            this.#scheduleReconnect();
+            return;
+        }
+        this.#socket = socket;
+
+        socket.addEventListener('open', () => {
+            this.#reconnectAttempt = 0;
+            this.#startPing();
+            if (this.#onConnect) this.#onConnect();
+        });
+
+        socket.addEventListener('message', (e: MessageEvent) => {
+            let msg: ChatWSIncoming;
+            try {
+                msg = JSON.parse(e.data as string) as ChatWSIncoming;
+            } catch {
+                return;
+            }
+            if (msg.type === 'pong') return;
+            this.#onMessage(msg);
+        });
+
+        socket.addEventListener('close', (e: CloseEvent) => {
+            this.#stopPing();
+            this.#socket = null;
+            if (this.#onClose) this.#onClose(e.code);
+            if (this.#closedByUser || (e.code >= 4400 && e.code < 4500)) return;
+            this.#scheduleReconnect();
+        });
+
+        socket.addEventListener('error', () => {
+            /* noop */
+        });
+    }
+
+    /**
+     * Планирует переподключение с экспоненциальным backoff (1s, 2s, 4s, 8s, 15s),
+     * после 4 попыток delay фиксируется на 15 секундах.
+     */
+    #scheduleReconnect(): void {
+        if (this.#closedByUser) return;
+        const delay = Math.min(15000, 1000 * 2 ** Math.min(this.#reconnectAttempt, 4));
+        this.#reconnectAttempt += 1;
+        this.#reconnectTimer = setTimeout(() => {
+            this.#reconnectTimer = null;
+            this.#open();
+        }, delay);
+    }
+
+    /**
+     * Сериализует и отправляет payload через WebSocket.
+     * @param payload - объект для JSON.stringify
+     * @returns true если send удался, false иначе
+     */
+    #send(payload: Record<string, unknown>): boolean {
+        if (!this.isOpen()) return false;
+        try {
+            nn(this.#socket).send(JSON.stringify(payload));
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Запускает ping-таймер (каждые 25 секунд).
+     */
+    #startPing(): void {
+        this.#stopPing();
+        this.#pingTimer = setInterval(() => this.#send({ type: 'ping' }), 25000);
+    }
+
+    /**
+     * Останавливает ping-таймер, если он активен.
+     */
+    #stopPing(): void {
+        if (this.#pingTimer !== null) {
+            clearInterval(this.#pingTimer);
+            this.#pingTimer = null;
+        }
+    }
+}

--- a/src/shared/api/chatTypes.ts
+++ b/src/shared/api/chatTypes.ts
@@ -1,0 +1,153 @@
+/**
+ * DTO одного сообщения переписки. Возвращается бэкендом в массиве истории
+ * и сохраняется в БД на стороне chat-сервиса. Соответствует
+ * api/proto/chat/chat.proto ChatMessage.
+ */
+export interface ChatMessageDTO {
+    /** Идентификатор сообщения в БД */
+    id: number;
+    /** Роль: 'user' / 'assistant' / 'system' */
+    role: string;
+    /** Текст сообщения */
+    content: string;
+    /** Имя модели, которой сгенерирован ответ (пусто для user-сообщений) */
+    model?: string;
+    /** Количество входных токенов (для assistant-сообщений) */
+    tokens_in: number;
+    /** Количество выходных токенов (для assistant-сообщений) */
+    tokens_out: number;
+    /** ID ноутбука, к которому привязано сообщение */
+    notebook_id: number;
+    /** Unix timestamp создания */
+    created_at: number;
+}
+
+/**
+ * Ответ на GET /chat/history — список сообщений в хронологическом порядке.
+ */
+export interface ChatHistoryResponse {
+    /** Массив сообщений */
+    messages: ChatMessageDTO[];
+}
+
+/**
+ * Пользовательские настройки чата с ИИ: выбранная модель и системный промпт.
+ */
+export interface ChatSettingsDTO {
+    /** Идентификатор выбранной модели */
+    model: string;
+    /** Системный промпт, подкладываемый перед каждым диалогом */
+    system_prompt: string;
+    /** Unix timestamp последнего изменения */
+    updated_at: number;
+}
+
+/**
+ * Запись использования по конкретной модели за всё время.
+ */
+export interface ChatUsageByModel {
+    /** Имя модели */
+    model: string;
+    /** Количество запросов */
+    requests: number;
+    /** Общее количество токенов (вход + выход) */
+    tokens: number;
+}
+
+/**
+ * Ответ на GET /chat/usage — расход за сегодня и за всё время + лимиты тарифа.
+ */
+export interface ChatUsageResponse {
+    /** Сколько запросов отправлено сегодня */
+    requests_today: number;
+    /** Сколько токенов потрачено сегодня */
+    tokens_today: number;
+    /** Суточный лимит запросов на текущем плане */
+    daily_request_limit: number;
+    /** Суточный лимит токенов на текущем плане */
+    daily_token_limit: number;
+    /** Общее число запросов за всё время */
+    total_requests: number;
+    /** Общее число токенов за всё время */
+    total_tokens: number;
+    /** Разбивка использования по моделям */
+    by_model: ChatUsageByModel[];
+}
+
+/**
+ * Описание одной модели — доступна или нет на текущем тарифе, и для каких
+ * планов она открыта (для UI-подсказки «доступно в Pro»).
+ */
+export interface AiModelDTO {
+    /** Идентификатор модели (например, openai/gpt-4o-mini) */
+    id: string;
+    /** Человекочитаемое имя для UI */
+    label: string;
+    /** Доступна ли модель на текущем тарифе пользователя */
+    available: boolean;
+    /** Минимальный план, на котором модель доступна ('free'|'pro'|'max') */
+    required_plan?: string;
+}
+
+/**
+ * Ответ на GET /chat/models — список всех известных моделей с пометкой
+ * доступности для текущего пользователя.
+ */
+export interface AiModelsResponse {
+    /** Массив моделей */
+    models: AiModelDTO[];
+}
+
+/**
+ * Опции контекста, которые фронт может приложить к сообщению чата:
+ * содержимое выделенной ячейки и/или дамп всего ноутбука. Бэкенд встроит
+ * их в подсказку для модели.
+ */
+export interface ChatContextOptions {
+    /** ID выделенной ячейки (если есть) */
+    cell_id?: number;
+    /** Содержимое выделенной ячейки */
+    cell_content?: string;
+    /** Язык выделенной ячейки */
+    cell_language?: string;
+    /** Сериализованный дамп всего ноутбука */
+    notebook_dump?: string;
+    /** Признак: включать ли весь ноутбук в подсказку */
+    include_notebook?: boolean;
+}
+
+/**
+ * Тип сообщений, которые фронт шлёт в WS чат.
+ */
+export interface ChatWSOutgoing {
+    /** Тип сообщения: 'message' для запроса, 'ping' для keepalive */
+    type: 'message' | 'ping';
+    /** ID ноутбука для привязки истории */
+    notebook_id?: number;
+    /** Текст пользовательского сообщения */
+    content?: string;
+    /** Выбранная модель (если пусто — серверная default-модель) */
+    model?: string;
+    /** Контекст диалога */
+    context?: ChatContextOptions;
+}
+
+/**
+ * Тип сообщений, которые сервер шлёт в WS чат.
+ */
+export interface ChatWSIncoming {
+    /** Тип события: 'chunk', 'done', 'error', 'pong' */
+    type: string;
+    /** Кусок ответа модели (при type='chunk') */
+    content?: string;
+    /** Количество входных токенов (приходит с done) */
+    tokens_in?: number;
+    /** Количество выходных токенов (приходит с done) */
+    tokens_out?: number;
+    /** ID assistant-сообщения в БД (приходит с done) */
+    message_id?: number;
+    /** Машиночитаемый код ошибки (при type='error') */
+    error_code?: string;
+    /** Текст ошибки для отображения пользователю */
+    error_message?: string;
+}

--- a/src/widgets/ai-chat-panel/AiChatPanel.scss
+++ b/src/widgets/ai-chat-panel/AiChatPanel.scss
@@ -1,0 +1,259 @@
+.ai-chat-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    background: var(--white);
+    font-family: var(--font-family-base);
+    font-size: var(--font-size-base);
+    color: var(--dark-primary);
+
+    &__header {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 12px;
+        border-bottom: 1px solid var(--cell-border);
+    }
+
+    &__title {
+        font-weight: 600;
+        color: var(--teal-green);
+    }
+
+    &__controls {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    &__label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: var(--font-size-small);
+        color: var(--accent);
+    }
+
+    &__model-select {
+        padding: 6px 8px;
+        border: 1px solid var(--cell-border);
+        border-radius: 6px;
+        font-family: inherit;
+        font-size: inherit;
+        background: var(--white);
+    }
+
+    &__context-toggles {
+        display: flex;
+        gap: 12px;
+        font-size: var(--font-size-small);
+        color: var(--accent);
+
+        label {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            cursor: pointer;
+        }
+    }
+
+    &__clear-btn {
+        align-self: flex-start;
+        padding: 4px 10px;
+        font-size: var(--font-size-small);
+    }
+
+    &__messages {
+        flex: 1;
+        overflow-y: auto;
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    &__empty {
+        color: var(--accent);
+        text-align: center;
+        margin-top: 32px;
+        font-size: var(--font-size-small);
+    }
+
+    &__message {
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+        max-width: 100%;
+
+        &--user {
+            flex-direction: row-reverse;
+            align-self: flex-end;
+            max-width: 90%;
+        }
+
+        &--assistant {
+            flex-direction: row;
+            align-self: flex-start;
+            max-width: 95%;
+        }
+    }
+
+    &__message-avatar {
+        flex-shrink: 0;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.5px;
+        user-select: none;
+    }
+
+    &__message--user &__message-avatar {
+        background: var(--teal-green);
+        color: var(--white);
+    }
+
+    &__message--assistant &__message-avatar {
+        background: var(--dark-primary);
+        color: var(--white);
+    }
+
+    &__message-bubble {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 8px 12px;
+        border-radius: 12px;
+        word-break: break-word;
+        white-space: pre-wrap;
+        position: relative;
+    }
+
+    &__message--user &__message-bubble {
+        background: var(--teal-green);
+        color: var(--white);
+        border-bottom-right-radius: 2px;
+    }
+
+    &__message--assistant &__message-bubble {
+        background: var(--light-grey);
+        color: var(--dark-primary);
+        border: 1px solid var(--cell-border);
+        border-bottom-left-radius: 2px;
+    }
+
+    &__message-author {
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+        opacity: 0.85;
+    }
+
+    &__message--user &__message-author {
+        color: rgba(255, 255, 255, 0.85);
+    }
+
+    &__message--assistant &__message-author {
+        color: var(--teal-green);
+    }
+
+    &__message-body {
+        font-size: var(--font-size-base);
+        line-height: 1.45;
+    }
+
+    &__message-meta {
+        font-size: var(--font-size-small);
+        color: var(--accent);
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+
+    &__insert-cell {
+        font-size: var(--font-size-small);
+        padding: 2px 8px;
+        border: 1px solid var(--teal-green);
+        border-radius: 4px;
+        background: var(--white);
+        color: var(--teal-green);
+        cursor: pointer;
+    }
+
+    &__thinking {
+        display: flex;
+        gap: 4px;
+        padding: 0 16px 8px;
+
+        span {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--accent);
+            animation: ai-chat-bounce 1.2s infinite ease-in-out;
+        }
+
+        span:nth-child(2) {
+            animation-delay: 0.15s;
+        }
+
+        span:nth-child(3) {
+            animation-delay: 0.3s;
+        }
+    }
+
+    &__error {
+        margin: 0 12px 8px;
+        padding: 8px;
+        background: var(--error-bg);
+        color: var(--error-red);
+        font-size: var(--font-size-small);
+        border-radius: 6px;
+    }
+
+    &__form {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 12px;
+        border-top: 1px solid var(--cell-border);
+    }
+
+    &__textarea {
+        resize: none;
+        padding: 8px;
+        border: 1px solid var(--cell-border);
+        border-radius: 6px;
+        font-family: inherit;
+        font-size: inherit;
+        min-height: 56px;
+        max-height: 180px;
+    }
+
+    &__send {
+        align-self: flex-end;
+        min-width: 110px;
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+    }
+}
+
+@keyframes ai-chat-bounce {
+    0%, 80%, 100% {
+        transform: translateY(0);
+        opacity: 0.6;
+    }
+    40% {
+        transform: translateY(-6px);
+        opacity: 1;
+    }
+}

--- a/src/widgets/ai-chat-panel/AiChatPanel.template.ts
+++ b/src/widgets/ai-chat-panel/AiChatPanel.template.ts
@@ -1,0 +1,57 @@
+/**
+ * Возвращает HTML-разметку панели AI-чата: шапка с селектом моделей и чекбоксами
+ * контекста, скроллируемая лента сообщений, индикатор «модель думает» и поле ввода.
+ * Реальные опции селекта и сообщения подставляются JS-кодом компонента в mount().
+ * @returns строка HTML для вставки в DOM
+ */
+export function AiChatPanelTemplate(): string {
+    return `
+<div class="ai-chat-panel">
+    <header class="ai-chat-panel__header">
+        <div class="ai-chat-panel__title">Чат с ИИ</div>
+        <div class="ai-chat-panel__controls">
+            <label class="ai-chat-panel__label">
+                Модель
+                <select class="ai-chat-panel__model-select" aria-label="Выбор модели">
+                    <option value="" disabled selected>Загрузка…</option>
+                </select>
+            </label>
+            <div class="ai-chat-panel__context-toggles">
+                <label>
+                    <input type="checkbox" class="ai-chat-panel__include-cell" />
+                    Текущая ячейка
+                </label>
+                <label>
+                    <input type="checkbox" class="ai-chat-panel__include-notebook" />
+                    Весь ноутбук
+                </label>
+            </div>
+            <button type="button" class="ai-chat-panel__clear-btn simple-btn" title="Очистить историю">
+                Очистить
+            </button>
+        </div>
+    </header>
+
+    <div class="ai-chat-panel__messages" aria-live="polite">
+        <div class="ai-chat-panel__empty">
+            Задайте вопрос ИИ — например, «Объясни этот код» или «Найди ошибку».
+        </div>
+    </div>
+
+    <div class="ai-chat-panel__thinking" hidden>
+        <span></span><span></span><span></span>
+    </div>
+
+    <div class="ai-chat-panel__error" hidden></div>
+
+    <form class="ai-chat-panel__form">
+        <textarea
+            class="ai-chat-panel__textarea"
+            rows="2"
+            placeholder="Спросите что угодно… (Shift+Enter — новая строка)"
+        ></textarea>
+        <button type="submit" class="ai-chat-panel__send accent-btn" disabled>Отправить</button>
+    </form>
+</div>
+`;
+}

--- a/src/widgets/ai-chat-panel/AiChatPanel.ts
+++ b/src/widgets/ai-chat-panel/AiChatPanel.ts
@@ -365,9 +365,7 @@ export class AiChatPanel extends BaseComponent {
                 break;
             case 'error':
                 this.#finishAssistant();
-                this.#showError(
-                    msg.error_message ?? msg.error_code ?? 'Ошибка при работе с ИИ'
-                );
+                this.#showError(msg.error_message ?? msg.error_code ?? 'Ошибка при работе с ИИ');
                 break;
             default:
                 break;

--- a/src/widgets/ai-chat-panel/AiChatPanel.ts
+++ b/src/widgets/ai-chat-panel/AiChatPanel.ts
@@ -1,0 +1,621 @@
+/* eslint-disable max-lines -- TODO(refactor): вынести #renderAssistantBody/#attachInsertButtons/#dumpNotebook в helpers рядом с виджетом */
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import { AiApi } from '../../shared/api/AiApi.js';
+import { ChatWS } from '../../shared/api/ChatWS.js';
+import type {
+    AiModelDTO,
+    ChatContextOptions,
+    ChatMessageDTO,
+    ChatWSIncoming
+} from '../../shared/api/chatTypes.js';
+import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+import { logError } from '../../shared/utils/logger.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { AiChatPanelTemplate } from './AiChatPanel.template.js';
+
+/**
+ * Имя CustomEvent, который слушает CodeCell / BlocksPage чтобы вставить
+ * сгенерированный ИИ блок кода в текущий ноутбук.
+ */
+export const AI_INSERT_CELL_EVENT = 'ai-chat:insert-cell';
+
+/**
+ * Имя CustomEvent, по которому панель чата открывается извне (например,
+ * из CodeCell при нажатии «Объяснить» / «Исправить через ИИ») и сразу
+ * подставляет preset-сообщение.
+ */
+export const AI_OPEN_WITH_PROMPT_EVENT = 'ai-chat:open-with-prompt';
+
+/**
+ * Полезная нагрузка события AI_INSERT_CELL_EVENT.
+ */
+export interface AiInsertCellDetail {
+    /** Код, который нужно вставить в новую ячейку */
+    code: string;
+    /** Язык программирования */
+    language: string;
+}
+
+/**
+ * Полезная нагрузка события AI_OPEN_WITH_PROMPT_EVENT.
+ */
+export interface AiOpenWithPromptDetail {
+    /** Текст preset-сообщения */
+    prompt: string;
+    /** Дополнительный контекст (необязательно) */
+    context?: ChatContextOptions;
+    /** Признак: автоматически отправлять сразу (true) или дать пользователю отредактировать (false) */
+    autoSend?: boolean;
+}
+
+/**
+ * Виджет AI-чата для боковой панели ноутбука. Управляет:
+ * - WebSocket-соединением для потоковых ответов модели,
+ * - REST-вызовами для истории, настроек, списка моделей,
+ * - локальной лентой сообщений и индикатором «думает».
+ *
+ * Связь с другими виджетами — через CustomEvent на document:
+ * - слушает AI_OPEN_WITH_PROMPT_EVENT, чтобы CodeCell мог попросить ИИ
+ *   объяснить ячейку или исправить ошибку;
+ * - диспатчит AI_INSERT_CELL_EVENT, когда пользователь нажимает «Вставить
+ *   в ячейку» на блоке кода в ответе модели.
+ */
+export class AiChatPanel extends BaseComponent {
+    #notebookId: number;
+    #api: AiApi;
+    #ws: ChatWS | null = null;
+    #messagesEl: HTMLElement | null = null;
+    #thinkingEl: HTMLElement | null = null;
+    #errorEl: HTMLElement | null = null;
+    #textareaEl: HTMLTextAreaElement | null = null;
+    #sendBtnEl: HTMLButtonElement | null = null;
+    #modelSelectEl: HTMLSelectElement | null = null;
+    #includeCellEl: HTMLInputElement | null = null;
+    #includeNotebookEl: HTMLInputElement | null = null;
+    #clearBtnEl: HTMLButtonElement | null = null;
+    #emptyEl: HTMLElement | null = null;
+    #currentAssistantContainer: HTMLElement | null = null;
+    #currentAssistantContent = '';
+    #streaming = false;
+    #presetHandler: ((e: Event) => void) | null = null;
+
+    /**
+     * Конструктор: рендерит HTML и сохраняет ссылки на DOM-узлы.
+     * @param parent - родительский элемент, в который панель будет смонтирована
+     * @param notebookId - ID ноутбука для привязки истории и контекста
+     */
+    public constructor(parent: HTMLElement, notebookId: number) {
+        super(null, parent);
+        this.#notebookId = notebookId;
+        this.#api = new AiApi();
+        this.#render();
+    }
+
+    /**
+     * Создаёт корневой DOM-элемент панели из шаблона и кэширует ссылки
+     * на интерактивные подэлементы.
+     */
+    #render(): void {
+        const wrap = document.createElement('div');
+        wrap.innerHTML = AiChatPanelTemplate().trim();
+        this._element = wrap.firstElementChild as HTMLElement;
+
+        this.#messagesEl = this._element.querySelector<HTMLElement>('.ai-chat-panel__messages');
+        this.#thinkingEl = this._element.querySelector<HTMLElement>('.ai-chat-panel__thinking');
+        this.#errorEl = this._element.querySelector<HTMLElement>('.ai-chat-panel__error');
+        this.#textareaEl = this._element.querySelector<HTMLTextAreaElement>(
+            '.ai-chat-panel__textarea'
+        );
+        this.#sendBtnEl = this._element.querySelector<HTMLButtonElement>('.ai-chat-panel__send');
+        this.#modelSelectEl = this._element.querySelector<HTMLSelectElement>(
+            '.ai-chat-panel__model-select'
+        );
+        this.#includeCellEl = this._element.querySelector<HTMLInputElement>(
+            '.ai-chat-panel__include-cell'
+        );
+        this.#includeNotebookEl = this._element.querySelector<HTMLInputElement>(
+            '.ai-chat-panel__include-notebook'
+        );
+        this.#clearBtnEl = this._element.querySelector<HTMLButtonElement>(
+            '.ai-chat-panel__clear-btn'
+        );
+        this.#emptyEl = this._element.querySelector<HTMLElement>('.ai-chat-panel__empty');
+    }
+
+    /**
+     * Монтирует панель в DOM, подключает обработчики, открывает WS-сессию,
+     * загружает историю и список моделей. Идемпотентно.
+     */
+    public mount(): void {
+        if (this._isMounted) return;
+        super.mount();
+
+        this._addListener(this.#sendBtnEl, 'click', (): void => {
+            this.#handleSubmit();
+        });
+        this._addListener(this.#textareaEl, 'input', (): void => {
+            this.#handleInput();
+        });
+        this._addListener(this.#textareaEl, 'keydown', (e: Event): void => {
+            this.#handleKeydown(e as KeyboardEvent);
+        });
+        this._addListener(this.#clearBtnEl, 'click', (): void => {
+            void this.#handleClear();
+        });
+        this._addListener(this._element.querySelector('form'), 'submit', (e: Event): void => {
+            e.preventDefault();
+        });
+
+        this.#presetHandler = (e: Event): void => {
+            const detail = (e as CustomEvent<AiOpenWithPromptDetail>).detail;
+            this.#applyPreset(detail);
+        };
+        document.addEventListener(AI_OPEN_WITH_PROMPT_EVENT, this.#presetHandler);
+
+        this.#openWS();
+        void this.#bootstrap();
+    }
+
+    /**
+     * Снимает обработчики, закрывает WS и очищает DOM. Должен быть вызван
+     * перед уничтожением виджета (например, при смене ноутбука).
+     */
+    public unmount(): void {
+        if (this.#presetHandler) {
+            document.removeEventListener(AI_OPEN_WITH_PROMPT_EVENT, this.#presetHandler);
+            this.#presetHandler = null;
+        }
+        if (this.#ws) {
+            this.#ws.close();
+            this.#ws = null;
+        }
+        super.unmount();
+    }
+
+    /**
+     * Открывает WebSocket-сессию и связывает её колбэки с локальными
+     * обработчиками входящих сообщений.
+     */
+    #openWS(): void {
+        this.#ws = new ChatWS({
+            onMessage: (m): void => {
+                this.#onWSMessage(m);
+            },
+            onClose: (code): void => {
+                if (code === 4403 || code === 1008) {
+                    this.#showError('Чат недоступен на текущем тарифе');
+                }
+            }
+        });
+        this.#ws.connect();
+    }
+
+    /**
+     * Подгружает историю, список моделей и пользовательские настройки.
+     * Любая ошибка пишется в errorEl, но не ломает работу панели.
+     */
+    async #bootstrap(): Promise<void> {
+        try {
+            const history = await this.#api.getHistory(this.#notebookId);
+            history.messages.forEach((m) => {
+                this.#renderMessage(m);
+            });
+        } catch (e) {
+            logError('AiChatPanel.history', e);
+        }
+        try {
+            const models = await this.#api.getModels();
+            this.#populateModelSelect(models.models);
+        } catch (e) {
+            logError('AiChatPanel.models', e);
+        }
+        try {
+            const settings = await this.#api.getSettings();
+            if (this.#modelSelectEl && settings.model !== '') {
+                this.#modelSelectEl.value = settings.model;
+            }
+        } catch (e) {
+            logError('AiChatPanel.settings', e);
+        }
+    }
+
+    /**
+     * Заполняет select моделей. Недоступные модели остаются в списке,
+     * но disabled и помечены меткой требуемого тарифа.
+     * @param models - список моделей из ответа /chat/models
+     */
+    #populateModelSelect(models: AiModelDTO[]): void {
+        if (!this.#modelSelectEl) return;
+        this.#modelSelectEl.innerHTML = '';
+        const available = models.filter((m) => m.available);
+        const locked = models.filter((m) => !m.available);
+
+        available.forEach((m) => {
+            const opt = document.createElement('option');
+            opt.value = m.id;
+            opt.textContent = m.label || m.id;
+            nn(this.#modelSelectEl).appendChild(opt);
+        });
+        locked.forEach((m) => {
+            const opt = document.createElement('option');
+            opt.value = m.id;
+            opt.disabled = true;
+            opt.textContent = `${m.label || m.id} — доступно в ${m.required_plan ?? 'pro'}`;
+            nn(this.#modelSelectEl).appendChild(opt);
+        });
+    }
+
+    /**
+     * Обработчик ввода в textarea: меняет disabled-флаг кнопки «Отправить»
+     * и автоматически растягивает поле под содержимое.
+     */
+    #handleInput(): void {
+        if (!this.#textareaEl || !this.#sendBtnEl) return;
+        const hasText = this.#textareaEl.value.trim().length > 0;
+        this.#sendBtnEl.disabled = !hasText || this.#streaming;
+        this.#textareaEl.style.height = 'auto';
+        this.#textareaEl.style.height = `${String(this.#textareaEl.scrollHeight)}px`;
+    }
+
+    /**
+     * Обрабатывает Enter без Shift — отправляет сообщение.
+     * @param e - keyboard-событие textarea
+     */
+    #handleKeydown(e: KeyboardEvent): void {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            this.#handleSubmit();
+        }
+    }
+
+    /**
+     * Собирает текущий контекст диалога (выделенная ячейка + опционально весь
+     * ноутбук) из чекбоксов панели.
+     * @returns объект ContextOptions для передачи в ChatWS.sendMessage
+     */
+    #collectContext(): ChatContextOptions {
+        const ctx: ChatContextOptions = {};
+        if (this.#includeCellEl?.checked === true) {
+            const cellContent = this.#findActiveCellContent();
+            if (cellContent) {
+                ctx.cell_content = cellContent.content;
+                ctx.cell_language = cellContent.language;
+            }
+        }
+        if (this.#includeNotebookEl?.checked === true) {
+            ctx.include_notebook = true;
+            ctx.notebook_dump = this.#dumpNotebook();
+        }
+        return ctx;
+    }
+
+    /**
+     * Собирает запрос (контент + контекст + модель) и отправляет в WS.
+     * Блокирует повторную отправку до завершения текущего ответа.
+     */
+    #handleSubmit(): void {
+        if (this.#streaming) return;
+        const text = this.#textareaEl?.value.trim() ?? '';
+        if (text === '') return;
+        if (!this.#ws || !this.#ws.isOpen()) {
+            this.#showError('Соединение с чатом потеряно, попробуйте обновить страницу');
+            return;
+        }
+
+        const selectedValue = this.#modelSelectEl?.value ?? '';
+        const model = selectedValue !== '' ? selectedValue : undefined;
+        const ctx = this.#collectContext();
+
+        const ok = this.#ws.sendMessage(this.#notebookId, text, model, ctx);
+        if (!ok) {
+            this.#showError('Не удалось отправить сообщение');
+            return;
+        }
+
+        this.#renderMessage({
+            id: -1,
+            role: 'user',
+            content: text,
+            tokens_in: 0,
+            tokens_out: 0,
+            notebook_id: this.#notebookId,
+            created_at: Math.floor(Date.now() / 1000)
+        });
+        if (this.#textareaEl) {
+            this.#textareaEl.value = '';
+            this.#textareaEl.style.height = 'auto';
+        }
+        if (this.#sendBtnEl) {
+            this.#sendBtnEl.disabled = true;
+        }
+        this.#startThinking();
+    }
+
+    /**
+     * Очищает историю переписки по текущему ноутбуку: и на сервере, и в DOM.
+     */
+    async #handleClear(): Promise<void> {
+        if (!confirm('Очистить историю чата для этого ноутбука?')) return; // eslint-disable-line no-alert -- minimal confirm UI; full modal will come with design pass
+        try {
+            await this.#api.clearHistory(this.#notebookId);
+            if (this.#messagesEl) {
+                this.#messagesEl.innerHTML = '';
+                if (this.#emptyEl) {
+                    this.#messagesEl.appendChild(this.#emptyEl);
+                }
+            }
+        } catch (e) {
+            logError('AiChatPanel.clear', e);
+            this.#showError('Не удалось очистить историю');
+        }
+    }
+
+    /**
+     * Обрабатывает входящее WS-сообщение и переводит UI в соответствующее
+     * состояние (печать чанка / завершение / ошибка).
+     * @param msg - событие из ChatWS
+     */
+    #onWSMessage(msg: ChatWSIncoming): void {
+        switch (msg.type) {
+            case 'chunk':
+                this.#appendAssistantChunk(msg.content ?? '');
+                break;
+            case 'done':
+                this.#finishAssistant();
+                break;
+            case 'error':
+                this.#finishAssistant();
+                this.#showError(
+                    msg.error_message ?? msg.error_code ?? 'Ошибка при работе с ИИ'
+                );
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Добавляет кусок ответа модели в текущий контейнер; создаёт контейнер,
+     * если приходит первый чанк.
+     * @param chunk - очередная порция текста
+     */
+    #appendAssistantChunk(chunk: string): void {
+        if (!this.#currentAssistantContainer) {
+            this.#stopThinking();
+            this.#currentAssistantContainer = this.#createMessageElement('assistant');
+            nn(this.#messagesEl).appendChild(this.#currentAssistantContainer);
+            this.#currentAssistantContent = '';
+        }
+        this.#currentAssistantContent += chunk;
+        const body = this.#currentAssistantContainer.querySelector<HTMLElement>(
+            '.ai-chat-panel__message-body'
+        );
+        if (body) {
+            body.innerHTML = this.#renderAssistantBody(this.#currentAssistantContent);
+        }
+        this.#scrollToBottom();
+    }
+
+    /**
+     * Завершает текущий ответ модели: сбрасывает буфер, разблокирует
+     * поле ввода и довешивает кнопки «Вставить в ячейку» на блоки кода.
+     */
+    #finishAssistant(): void {
+        this.#stopThinking();
+        if (this.#currentAssistantContainer) {
+            this.#attachInsertButtons(this.#currentAssistantContainer);
+            this.#currentAssistantContainer = null;
+            this.#currentAssistantContent = '';
+        }
+        this.#streaming = false;
+        this.#handleInput();
+    }
+
+    /**
+     * Рисует одно сообщение в ленте (используется для истории и для
+     * только что отправленных пользовательских сообщений).
+     * @param msg - DTO сообщения
+     */
+    #renderMessage(msg: ChatMessageDTO): void {
+        if (this.#emptyEl?.parentElement) {
+            this.#emptyEl.parentElement.removeChild(this.#emptyEl);
+        }
+        const el = this.#createMessageElement(msg.role === 'assistant' ? 'assistant' : 'user');
+        const body = el.querySelector<HTMLElement>('.ai-chat-panel__message-body');
+        if (body) {
+            if (msg.role === 'assistant') {
+                body.innerHTML = this.#renderAssistantBody(msg.content);
+            } else {
+                body.textContent = msg.content;
+            }
+        }
+        nn(this.#messagesEl).appendChild(el);
+        if (msg.role === 'assistant') {
+            this.#attachInsertButtons(el);
+        }
+        this.#scrollToBottom();
+    }
+
+    /**
+     * Создаёт DOM-элемент пустого сообщения c подготовленным телом, аватаром
+     * и явной плашкой автора («Вы» / «ИИ») для контрастного разделения
+     * пользовательских и ассистентских реплик.
+     * @param role - 'user' или 'assistant'
+     * @returns корневой div сообщения
+     */
+    #createMessageElement(role: 'user' | 'assistant'): HTMLElement {
+        const el = document.createElement('div');
+        el.className = `ai-chat-panel__message ai-chat-panel__message--${role}`;
+        const label = role === 'user' ? 'Вы' : 'ИИ';
+        const avatar = role === 'user' ? 'В' : 'ИИ';
+        el.innerHTML = `
+            <div class="ai-chat-panel__message-avatar" aria-hidden="true">${avatar}</div>
+            <div class="ai-chat-panel__message-bubble">
+                <div class="ai-chat-panel__message-author">${label}</div>
+                <div class="ai-chat-panel__message-body"></div>
+            </div>
+        `;
+        return el;
+    }
+
+    /**
+     * Конвертирует ответ ассистента в безопасный HTML: экранирует всё,
+     * затем заменяет fenced code-блоки ```lang\n...\n``` на <pre><code>...
+     * @param raw - сырой текст ответа
+     * @returns HTML-строка для innerHTML
+     */
+    #renderAssistantBody(raw: string): string {
+        const escaped = escapeHtml(raw);
+        return escaped.replace(
+            /```([a-zA-Z0-9_+-]*)\n([\s\S]*?)```/g,
+            (_match, lang: string, body: string) =>
+                `<pre class="ai-chat-panel__code" data-lang="${escapeHtml(lang)}"><code>${body}</code><button type="button" class="ai-chat-panel__insert-cell">Вставить в ячейку</button></pre>`
+        );
+    }
+
+    /**
+     * Навешивает обработчики на кнопки «Вставить в ячейку» внутри
+     * указанного контейнера сообщения.
+     * @param container - корневой элемент одного сообщения
+     */
+    #attachInsertButtons(container: HTMLElement): void {
+        const buttons = container.querySelectorAll<HTMLButtonElement>(
+            '.ai-chat-panel__insert-cell'
+        );
+        buttons.forEach((btn) => {
+            btn.addEventListener('click', () => {
+                const pre = btn.closest('pre');
+                if (!pre) return;
+                const code = pre.querySelector('code')?.textContent ?? '';
+                const language = pre.dataset.lang ?? '';
+                document.dispatchEvent(
+                    new CustomEvent<AiInsertCellDetail>(AI_INSERT_CELL_EVENT, {
+                        detail: { code, language }
+                    })
+                );
+                this.#copyToClipboard(code, btn);
+            });
+        });
+    }
+
+    /**
+     * Копирует код в буфер обмена и кратко меняет надпись на кнопке,
+     * чтобы пользователь видел подтверждение. Fallback на случай, если
+     * страница не подцепила событие AI_INSERT_CELL_EVENT.
+     * @param code - содержимое кодового блока
+     * @param btn - DOM-кнопка, на которой показывается фидбек
+     */
+    #copyToClipboard(code: string, btn: HTMLButtonElement): void {
+        navigator.clipboard
+            .writeText(code)
+            .then(() => {
+                const original = btn.textContent;
+                btn.textContent = 'Скопировано';
+                setTimeout(() => {
+                    if (btn.textContent === 'Скопировано') {
+                        btn.textContent = original;
+                    }
+                }, 1500);
+            })
+            .catch((e: unknown) => {
+                logError('AiChatPanel.clipboard', e);
+            });
+    }
+
+    /**
+     * Скроллит ленту сообщений к низу, чтобы новое сообщение было видно.
+     */
+    #scrollToBottom(): void {
+        if (!this.#messagesEl) return;
+        this.#messagesEl.scrollTop = this.#messagesEl.scrollHeight;
+    }
+
+    /**
+     * Показывает индикатор «модель думает» и блокирует отправку.
+     */
+    #startThinking(): void {
+        this.#streaming = true;
+        if (this.#thinkingEl) this.#thinkingEl.hidden = false;
+        if (this.#errorEl) this.#errorEl.hidden = true;
+    }
+
+    /**
+     * Прячет индикатор «модель думает» (вызывается при первом чанке).
+     */
+    #stopThinking(): void {
+        if (this.#thinkingEl) this.#thinkingEl.hidden = true;
+    }
+
+    /**
+     * Выводит сообщение об ошибке в специальный блок и логирует.
+     * @param text - текст ошибки для пользователя
+     */
+    #showError(text: string): void {
+        if (this.#errorEl) {
+            this.#errorEl.textContent = text;
+            this.#errorEl.hidden = false;
+        }
+        this.#streaming = false;
+        this.#handleInput();
+    }
+
+    /**
+     * Применяет preset-запрос (приходит от CodeCell через CustomEvent).
+     * Подставляет текст в textarea и при autoSend сразу отправляет.
+     * @param detail - содержимое события AI_OPEN_WITH_PROMPT_EVENT
+     */
+    #applyPreset(detail: AiOpenWithPromptDetail): void {
+        if (!this.#textareaEl) return;
+        this.#textareaEl.value = detail.prompt;
+        this.#handleInput();
+        const hasCellContext = (detail.context?.cell_content ?? '') !== '';
+        if (hasCellContext && this.#includeCellEl) {
+            this.#includeCellEl.checked = true;
+        }
+        if (detail.autoSend === true) {
+            this.#handleSubmit();
+        } else {
+            this.#textareaEl.focus();
+        }
+    }
+
+    /**
+     * Достаёт содержимое активной (focused) CodeCell со страницы — нужно для
+     * подмешивания в контекст по чекбоксу «Текущая ячейка». Не SPA-friendly,
+     * зато не требует прямой ссылки на CellList.
+     * @returns текст и язык или null если активная ячейка не найдена
+     */
+    #findActiveCellContent(): { content: string; language: string } | null {
+        const active = document.querySelector<HTMLElement>('.cell--active, .code-cell--focused');
+        if (!active) return null;
+        const textarea = active.querySelector<HTMLTextAreaElement>('textarea');
+        if (!textarea) return null;
+        return {
+            content: textarea.value,
+            language: active.dataset.language ?? ''
+        };
+    }
+
+    /**
+     * Сериализует весь ноутбук в текстовый дамп (один блок за другим,
+     * code-блоки помечены fenced-разделителями). Используется для
+     * чекбокса «Весь ноутбук».
+     * @returns строка-дамп или пустая строка, если ничего не нашли
+     */
+    #dumpNotebook(): string {
+        const cells = document.querySelectorAll<HTMLElement>('[data-block-id]');
+        const parts: string[] = [];
+        cells.forEach((cell) => {
+            const lang = cell.dataset.language ?? '';
+            const textarea = cell.querySelector<HTMLTextAreaElement>('textarea');
+            const content = textarea?.value ?? '';
+            if (content.trim() === '') return;
+            if (lang !== '') {
+                parts.push(`\`\`\`${lang}\n${content}\n\`\`\``);
+            } else {
+                parts.push(content);
+            }
+        });
+        return parts.join('\n\n');
+    }
+}

--- a/src/widgets/ai-settings/AiSettings.scss
+++ b/src/widgets/ai-settings/AiSettings.scss
@@ -1,0 +1,84 @@
+.ai-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 24px;
+    max-width: 640px;
+
+    &__title {
+        margin: 0;
+        color: var(--dark-primary);
+        font-size: 20px;
+    }
+
+    &__subtitle {
+        margin: 0 0 8px;
+        font-size: 14px;
+        color: var(--accent);
+    }
+
+    &__field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    &__label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-weight: 600;
+        color: var(--dark-primary);
+    }
+
+    &__model-select,
+    &__prompt {
+        padding: 8px 10px;
+        border: 1px solid var(--cell-border);
+        border-radius: 6px;
+        font: inherit;
+        font-size: var(--font-size-base);
+        background: var(--white);
+    }
+
+    &__prompt {
+        resize: vertical;
+        font-family: var(--font-family-mono);
+        min-height: 120px;
+    }
+
+    &__hint {
+        margin: 0;
+        font-size: var(--font-size-small);
+        color: var(--accent);
+    }
+
+    &__usage {
+        background: var(--code-bg);
+        border: 1px solid var(--cell-border);
+        border-radius: 8px;
+        padding: 12px 16px;
+    }
+
+    &__usage-row {
+        display: flex;
+        justify-content: space-between;
+        padding: 4px 0;
+        font-size: var(--font-size-base);
+    }
+
+    &__actions {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    &__save {
+        min-width: 140px;
+    }
+
+    &__status {
+        font-size: var(--font-size-small);
+        color: var(--teal-green);
+    }
+}

--- a/src/widgets/ai-settings/AiSettings.template.ts
+++ b/src/widgets/ai-settings/AiSettings.template.ts
@@ -1,0 +1,52 @@
+/**
+ * Рендерит секцию настроек ИИ для страницы профиля: выбор модели,
+ * системный промпт и блок суточного использования.
+ * @returns HTML-строка для innerHTML
+ */
+export function AiSettingsTemplate(): string {
+    return `
+<section class="ai-settings">
+    <h2 class="ai-settings__title">Настройки ИИ</h2>
+
+    <div class="ai-settings__field">
+        <label class="ai-settings__label">
+            Модель по умолчанию
+            <select class="ai-settings__model-select">
+                <option value="" disabled selected>Загрузка…</option>
+            </select>
+        </label>
+        <p class="ai-settings__hint" data-plan-hint></p>
+    </div>
+
+    <div class="ai-settings__field">
+        <label class="ai-settings__label">
+            Системный промпт
+            <textarea
+                class="ai-settings__prompt"
+                rows="6"
+                maxlength="8000"
+                placeholder="Например: «Ты — помощник в области data science»"
+            ></textarea>
+        </label>
+        <p class="ai-settings__hint">До 8000 символов. Подставляется автоматически перед каждым диалогом.</p>
+    </div>
+
+    <div class="ai-settings__usage" data-usage>
+        <h3 class="ai-settings__subtitle">Использование сегодня</h3>
+        <div class="ai-settings__usage-row">
+            <span>Запросы</span>
+            <span data-usage-requests>—</span>
+        </div>
+        <div class="ai-settings__usage-row">
+            <span>Токены</span>
+            <span data-usage-tokens>—</span>
+        </div>
+    </div>
+
+    <div class="ai-settings__actions">
+        <button type="button" class="ai-settings__save accent-btn">Сохранить</button>
+        <span class="ai-settings__status" data-save-status></span>
+    </div>
+</section>
+`;
+}

--- a/src/widgets/ai-settings/AiSettings.ts
+++ b/src/widgets/ai-settings/AiSettings.ts
@@ -1,0 +1,170 @@
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import { AiApi } from '../../shared/api/AiApi.js';
+import type { AiModelDTO } from '../../shared/api/chatTypes.js';
+import { logError } from '../../shared/utils/logger.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { AiSettingsTemplate } from './AiSettings.template.js';
+
+/**
+ * Секция настроек ИИ в `/profile`. Позволяет пользователю выбрать модель
+ * по умолчанию (из whitelist его тарифа) и задать системный промпт; рядом
+ * показывает суточное использование (запросы / токены) с лимитом тарифа.
+ */
+export class AiSettings extends BaseComponent {
+    #api: AiApi;
+    #modelSelectEl: HTMLSelectElement | null = null;
+    #promptEl: HTMLTextAreaElement | null = null;
+    #saveBtnEl: HTMLButtonElement | null = null;
+    #statusEl: HTMLElement | null = null;
+    #planHintEl: HTMLElement | null = null;
+    #usageReqEl: HTMLElement | null = null;
+    #usageTokEl: HTMLElement | null = null;
+
+    /**
+     * Конструктор: рендерит шаблон и кеширует ссылки на DOM-узлы.
+     * @param parent - родительский контейнер секции профиля
+     */
+    public constructor(parent: HTMLElement) {
+        super(null, parent);
+        this.#api = new AiApi();
+        this.#render();
+    }
+
+    /**
+     * Создаёт корневой DOM-элемент из шаблона.
+     */
+    #render(): void {
+        const wrap = document.createElement('div');
+        wrap.innerHTML = AiSettingsTemplate().trim();
+        this._element = wrap.firstElementChild as HTMLElement;
+
+        this.#modelSelectEl = this._element.querySelector<HTMLSelectElement>(
+            '.ai-settings__model-select'
+        );
+        this.#promptEl = this._element.querySelector<HTMLTextAreaElement>('.ai-settings__prompt');
+        this.#saveBtnEl = this._element.querySelector<HTMLButtonElement>('.ai-settings__save');
+        this.#statusEl = this._element.querySelector<HTMLElement>('[data-save-status]');
+        this.#planHintEl = this._element.querySelector<HTMLElement>('[data-plan-hint]');
+        this.#usageReqEl = this._element.querySelector<HTMLElement>('[data-usage-requests]');
+        this.#usageTokEl = this._element.querySelector<HTMLElement>('[data-usage-tokens]');
+    }
+
+    /**
+     * Монтирует секцию, подключает обработчики и параллельно подгружает
+     * модели, текущие настройки и статистику.
+     */
+    public mount(): void {
+        if (this._isMounted) return;
+        super.mount();
+        this._addListener(this.#saveBtnEl, 'click', (): void => {
+            void this.#handleSave();
+        });
+
+        void this.#loadAll();
+    }
+
+    /**
+     * Снимает секцию и обработчики (вызывается родителем при переключении вкладки).
+     */
+    public unmount(): void {
+        if (!this._isMounted) return;
+        super.unmount();
+    }
+
+    /**
+     * Параллельно загружает модели, настройки и использование. Ошибки
+     * каждого вызова не прерывают остальные.
+     */
+    async #loadAll(): Promise<void> {
+        try {
+            const models = await this.#api.getModels();
+            this.#populateModels(models.models);
+        } catch (e) {
+            logError('AiSettings.models', e);
+        }
+        try {
+            const settings = await this.#api.getSettings();
+            if (this.#modelSelectEl && settings.model) {
+                this.#modelSelectEl.value = settings.model;
+            }
+            if (this.#promptEl) {
+                this.#promptEl.value = settings.system_prompt;
+            }
+        } catch (e) {
+            logError('AiSettings.settings', e);
+        }
+        try {
+            const usage = await this.#api.getUsage();
+            if (this.#usageReqEl) {
+                this.#usageReqEl.textContent = `${String(usage.requests_today)} / ${String(usage.daily_request_limit)}`;
+            }
+            if (this.#usageTokEl) {
+                this.#usageTokEl.textContent = `${String(usage.tokens_today)} / ${String(usage.daily_token_limit)}`;
+            }
+        } catch (e) {
+            logError('AiSettings.usage', e);
+        }
+    }
+
+    /**
+     * Заполняет селект моделей: сначала доступные, потом залоченные
+     * с пометкой тарифа. Если все модели одного тарифа недоступны —
+     * подсказывает обновиться.
+     * @param models - список моделей с пометкой доступности
+     */
+    #populateModels(models: AiModelDTO[]): void {
+        if (!this.#modelSelectEl) return;
+        this.#modelSelectEl.innerHTML = '';
+        const available = models.filter((m) => m.available);
+        const locked = models.filter((m) => !m.available);
+
+        available.forEach((m) => {
+            const opt = document.createElement('option');
+            opt.value = m.id;
+            opt.textContent = m.label || m.id;
+            nn(this.#modelSelectEl).appendChild(opt);
+        });
+        locked.forEach((m) => {
+            const opt = document.createElement('option');
+            opt.value = m.id;
+            opt.disabled = true;
+            opt.textContent = `${m.label || m.id} — доступно в ${m.required_plan ?? 'pro'}`;
+            nn(this.#modelSelectEl).appendChild(opt);
+        });
+        if (available.length === 0 && this.#planHintEl) {
+            this.#planHintEl.textContent =
+                'На вашем тарифе модели недоступны. Перейдите в раздел «Подписка», чтобы открыть чат с ИИ.';
+        } else if (locked.length > 0 && this.#planHintEl) {
+            this.#planHintEl.textContent =
+                'Доступно больше моделей на тарифах Pro/Max.';
+        }
+    }
+
+    /**
+     * Отправляет PUT /chat/settings с текущими model и system_prompt,
+     * показывает статус «Сохранено» на 1.5 секунды.
+     */
+    async #handleSave(): Promise<void> {
+        if (!this.#modelSelectEl || !this.#promptEl || !this.#saveBtnEl) return;
+        const model = this.#modelSelectEl.value;
+        const prompt = this.#promptEl.value;
+        this.#saveBtnEl.disabled = true;
+        try {
+            await this.#api.updateSettings(model, prompt);
+            if (this.#statusEl) {
+                this.#statusEl.textContent = 'Сохранено';
+                setTimeout(() => {
+                    if (this.#statusEl) this.#statusEl.textContent = '';
+                }, 1500);
+            }
+        } catch (e) {
+            logError('AiSettings.save', e);
+            if (this.#statusEl) {
+                this.#statusEl.style.color = 'var(--error-red)';
+                this.#statusEl.textContent = e instanceof Error ? e.message : 'Не удалось сохранить';
+            }
+        } finally {
+            this.#saveBtnEl.disabled = false;
+        }
+    }
+}

--- a/src/widgets/ai-settings/AiSettings.ts
+++ b/src/widgets/ai-settings/AiSettings.ts
@@ -135,8 +135,7 @@ export class AiSettings extends BaseComponent {
             this.#planHintEl.textContent =
                 'На вашем тарифе модели недоступны. Перейдите в раздел «Подписка», чтобы открыть чат с ИИ.';
         } else if (locked.length > 0 && this.#planHintEl) {
-            this.#planHintEl.textContent =
-                'Доступно больше моделей на тарифах Pro/Max.';
+            this.#planHintEl.textContent = 'Доступно больше моделей на тарифах Pro/Max.';
         }
     }
 
@@ -161,7 +160,8 @@ export class AiSettings extends BaseComponent {
             logError('AiSettings.save', e);
             if (this.#statusEl) {
                 this.#statusEl.style.color = 'var(--error-red)';
-                this.#statusEl.textContent = e instanceof Error ? e.message : 'Не удалось сохранить';
+                this.#statusEl.textContent =
+                    e instanceof Error ? e.message : 'Не удалось сохранить';
             }
         } finally {
             this.#saveBtnEl.disabled = false;

--- a/src/widgets/notebook-sidebar/NotebookSidebar.scss
+++ b/src/widgets/notebook-sidebar/NotebookSidebar.scss
@@ -46,6 +46,36 @@
     background: var(--white);
     border-right: 1px solid var(--cell-border);
     overflow-y: auto;
+    position: relative;
+    min-width: 220px;
+    max-width: 800px;
+}
+
+.notebook-sidebar__resize-handle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 6px;
+    height: 100%;
+    cursor: col-resize;
+    z-index: 5;
+    background: transparent;
+    transition: background 0.15s ease;
+}
+
+.notebook-sidebar__resize-handle:hover,
+.notebook-sidebar__resizing .notebook-sidebar__resize-handle {
+    background: var(--teal-green-10);
+}
+
+.notebook-sidebar__resizing {
+    cursor: col-resize !important;
+    user-select: none;
+}
+
+.notebook-sidebar__resizing * {
+    cursor: col-resize !important;
+    user-select: none !important;
 }
 
 .notebook-sidebar__panel--visible {
@@ -168,4 +198,24 @@ mark.find-match--current {
     font-size: 13px;
     color: var(--line-number-color);
     margin: 0;
+}
+
+.notebook-sidebar__panel--ai-chat {
+    width: 360px;
+    overflow: hidden;
+}
+
+.notebook-sidebar__panel--ai-chat.notebook-sidebar__panel--visible {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.notebook-sidebar__panel-content--ai-chat {
+    padding: 0;
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
 }

--- a/src/widgets/notebook-sidebar/NotebookSidebar.template.ts
+++ b/src/widgets/notebook-sidebar/NotebookSidebar.template.ts
@@ -27,8 +27,13 @@ export function NotebookSidebarTemplate(): string {
                 <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/>
             </svg>
         </button>
+        <button class="notebook-sidebar__icon-btn" data-panel="ai-chat" title="Чат с ИИ">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"/>
+            </svg>
+        </button>
     </div>
-    <div class="notebook-sidebar__panel notebook-sidebar__panel--search">
+    <div class="notebook-sidebar__panel notebook-sidebar__panel--search" data-panel-name="search">
         <h3 class="notebook-sidebar__panel-title">Найти и заменить</h3>
         <div class="notebook-sidebar__panel-content">
             <input type="text" class="notebook-sidebar__input notebook-sidebar__find-input" placeholder="Найти...">
@@ -49,19 +54,22 @@ export function NotebookSidebarTemplate(): string {
             </div>
         </div>
     </div>
-    <div class="notebook-sidebar__panel notebook-sidebar__panel--toc">
+    <div class="notebook-sidebar__panel notebook-sidebar__panel--toc" data-panel-name="toc">
         <h3 class="notebook-sidebar__panel-title">Содержание</h3>
         <div class="notebook-sidebar__panel-content">
             <p class="notebook-sidebar__placeholder">Нет заголовков</p>
         </div>
     </div>
-    <div class="notebook-sidebar__panel notebook-sidebar__panel--files">
+    <div class="notebook-sidebar__panel notebook-sidebar__panel--files" data-panel-name="files">
         <h3 class="notebook-sidebar__panel-title">Файлы</h3>
         <div class="notebook-sidebar__panel-content">
             <p class="notebook-sidebar__placeholder">Нет файлов</p>
         </div>
     </div>
-    <div class="notebook-sidebar__panel notebook-sidebar__panel--resources">
+    <div class="notebook-sidebar__panel notebook-sidebar__panel--ai-chat" data-panel-name="ai-chat">
+        <div class="notebook-sidebar__panel-content notebook-sidebar__panel-content--ai-chat" data-ai-chat-mount></div>
+    </div>
+    <div class="notebook-sidebar__panel notebook-sidebar__panel--resources" data-panel-name="resources">
         <h3 class="notebook-sidebar__panel-title">Ресурсы</h3>
         <div class="notebook-sidebar__panel-content">
             <div class="container-stats container-stats--sidebar container-stats--inactive">

--- a/src/widgets/notebook-sidebar/NotebookSidebar.ts
+++ b/src/widgets/notebook-sidebar/NotebookSidebar.ts
@@ -91,6 +91,12 @@ interface NotebookSidebarCallbacks {
     searchTarget?: NotebookSearchAdapter;
     /** ID notebook'а — нужен для resources-панели (поллинг RunnerApi) */
     notebookId?: string | number;
+    /**
+     * Фабрика монтирования AI-чат-панели. Вызывается ровно один раз при
+     * первом открытии вкладки чата — даёт страницу контроль над
+     * созданием/конфигурацией виджета без круговой зависимости.
+     */
+    mountAiChat?: (container: HTMLElement) => void;
 }
 
 /**
@@ -109,6 +115,11 @@ export class NotebookSidebar extends BaseComponent {
     #statsWs: StatsWS | null = null;
     #ramHistory: number[] = [];
     #cpuHistory: number[] = [];
+    #mountAiChat: ((container: HTMLElement) => void) | null = null;
+    #aiChatMounted = false;
+    #resizeActive: { panel: HTMLElement; startX: number; startWidth: number } | null = null;
+    #resizeMoveHandler: ((e: MouseEvent) => void) | null = null;
+    #resizeUpHandler: (() => void) | null = null;
 
     /**
      * Создаёт сайдбар. searchTarget опционален — без него search-панель
@@ -118,11 +129,12 @@ export class NotebookSidebar extends BaseComponent {
      */
     public constructor(
         parent: HTMLElement,
-        { searchTarget, notebookId }: NotebookSidebarCallbacks = {}
+        { searchTarget, notebookId, mountAiChat }: NotebookSidebarCallbacks = {}
     ) {
         super(null, parent);
         this.#searchTarget = searchTarget ?? null;
         this.#notebookId = notebookId;
+        this.#mountAiChat = mountAiChat ?? null;
         this.#render();
     }
 
@@ -142,6 +154,8 @@ export class NotebookSidebar extends BaseComponent {
         if (this._isMounted) return;
         super.mount();
         this.#attachEvents();
+        this.#attachResizeHandles();
+        this.#applySavedWidths();
     }
 
     /**
@@ -150,6 +164,7 @@ export class NotebookSidebar extends BaseComponent {
     public unmount(): void {
         if (!this._isMounted) return;
         this.#stopStatsWS();
+        this.#cleanupResize();
         super.unmount();
     }
 
@@ -334,6 +349,133 @@ export class NotebookSidebar extends BaseComponent {
         if (panelName === 'resources') {
             this.#startStatsWS();
         }
+        if (panelName === 'ai-chat') {
+            this.#ensureAiChatMounted();
+        }
+    }
+
+    /**
+     * Вставляет в каждую панель сайдбара невидимый resize-handle на правой
+     * границе. При drag-е (mousedown→mousemove→mouseup) меняет ширину панели
+     * с min/max-ограничением и сохраняет финальное значение в localStorage,
+     * ключом служит имя панели из data-panel-name.
+     */
+    #attachResizeHandles(): void {
+        const panels = this._element.querySelectorAll<HTMLElement>('.notebook-sidebar__panel');
+        panels.forEach((panel) => {
+            const handle = document.createElement('div');
+            handle.className = 'notebook-sidebar__resize-handle';
+            panel.appendChild(handle);
+            this._addListener(handle, 'mousedown', (e: Event): void => {
+                this.#startResize(panel, e as MouseEvent);
+            });
+        });
+    }
+
+    /**
+     * Запускает drag-resize: сохраняет стартовую ширину и X, и навешивает
+     * глобальные mousemove/mouseup на document. Document.body получает
+     * курсор col-resize и user-select:none, чтобы текст не выделялся.
+     * @param panel - панель, которую ресайзим
+     * @param event - mousedown-событие
+     */
+    #startResize(panel: HTMLElement, event: MouseEvent): void {
+        event.preventDefault();
+        this.#resizeActive = {
+            panel,
+            startX: event.clientX,
+            startWidth: panel.getBoundingClientRect().width
+        };
+        document.body.classList.add('notebook-sidebar__resizing');
+        this.#resizeMoveHandler = (e: MouseEvent): void => {
+            this.#onResizeMove(e);
+        };
+        this.#resizeUpHandler = (): void => {
+            this.#onResizeEnd();
+        };
+        document.addEventListener('mousemove', this.#resizeMoveHandler);
+        document.addEventListener('mouseup', this.#resizeUpHandler);
+    }
+
+    /**
+     * Обработчик mousemove во время drag-resize: вычисляет новую ширину
+     * с зажимом в диапазон [220, 800] px и применяет к панели.
+     * @param e - событие mousemove
+     */
+    #onResizeMove(e: MouseEvent): void {
+        if (!this.#resizeActive) return;
+        const delta = e.clientX - this.#resizeActive.startX;
+        const width = Math.max(220, Math.min(800, this.#resizeActive.startWidth + delta));
+        this.#resizeActive.panel.style.width = `${String(width)}px`;
+    }
+
+    /**
+     * Завершает drag-resize: снимает глобальные слушатели, восстанавливает
+     * курсор/selection и сохраняет финальную ширину в localStorage.
+     */
+    #onResizeEnd(): void {
+        if (!this.#resizeActive) return;
+        const panelName = this.#resizeActive.panel.dataset.panelName ?? '';
+        const width = this.#resizeActive.panel.style.width;
+        if (panelName !== '' && width !== '') {
+            try {
+                localStorage.setItem(`notebook_sidebar_width:${panelName}`, width);
+            } catch {
+                /* private mode / quota — игнорируем */
+            }
+        }
+        this.#cleanupResize();
+    }
+
+    /**
+     * Снимает глобальные resize-слушатели и сбрасывает active state.
+     * Вызывается как из onResizeEnd, так и из unmount.
+     */
+    #cleanupResize(): void {
+        document.body.classList.remove('notebook-sidebar__resizing');
+        if (this.#resizeMoveHandler) {
+            document.removeEventListener('mousemove', this.#resizeMoveHandler);
+            this.#resizeMoveHandler = null;
+        }
+        if (this.#resizeUpHandler) {
+            document.removeEventListener('mouseup', this.#resizeUpHandler);
+            this.#resizeUpHandler = null;
+        }
+        this.#resizeActive = null;
+    }
+
+    /**
+     * При маунте подтягивает сохранённые ширины панелей из localStorage и
+     * применяет их inline-стилем — чтобы при перезагрузке страницы пользователь
+     * получил тот же размер.
+     */
+    #applySavedWidths(): void {
+        const panels = this._element.querySelectorAll<HTMLElement>('.notebook-sidebar__panel');
+        panels.forEach((panel) => {
+            const name = panel.dataset.panelName ?? '';
+            if (name === '') return;
+            try {
+                const saved = localStorage.getItem(`notebook_sidebar_width:${name}`);
+                if (saved !== null && saved !== '') {
+                    panel.style.width = saved;
+                }
+            } catch {
+                /* private mode — оставляем CSS default */
+            }
+        });
+    }
+
+    /**
+     * Лениво монтирует AI-чат-панель при первом открытии вкладки. Повторные
+     * открытия просто переиспользуют существующий компонент.
+     */
+    #ensureAiChatMounted(): void {
+        if (this.#aiChatMounted) return;
+        if (!this.#mountAiChat) return;
+        const container = this._element.querySelector<HTMLElement>('[data-ai-chat-mount]');
+        if (!container) return;
+        this.#mountAiChat(container);
+        this.#aiChatMounted = true;
     }
 
     /**


### PR DESCRIPTION
## Что

Виджет чата с ИИ в боковой панели редактора ноутбука + вкладка настроек в профиле. Бэкенд — отдельный микросервис chat ([go-park-mail-ru#109](https://github.com/go-park-mail-ru/2026_1_KISS/pull/109)), сообщения идут потоком через WebSocket.

## Изменения

- `src/shared/api/chatTypes.ts`, `AiApi.ts`, `ChatWS.ts` — DTO, REST-обёртка и WS-клиент с авто-reconnect/ping.
- `src/widgets/ai-chat-panel/*` — основной виджет: потоковый рендер, селект моделей с пометкой locked, чекбоксы контекста, парсинг ```code``` блоков с кнопкой «Вставить в ячейку».
- `src/widgets/ai-settings/*` — вкладка ИИ в профиле: модель по умолчанию, системный промпт, суточное использование.
- `src/widgets/notebook-sidebar/*`:
  - 5-я иконка чата с lazy-mount панели через фабрику `mountAiChat`;
  - drag-resize правой границы всех панелей (220-800 px), ширина сохраняется в localStorage.
- `src/pages/blocks/BlocksPage.ts` — передача фабрики чата в sidebar.
- `src/pages/profile/ProfilePage*.ts` — пункт sidebar и регистрация в SECTION_MAP.
- `src/app/index.scss` — подключение стилей новых виджетов.

## UI

- Сообщения чётко разделены: аватары + цветные bubbles + плашка автора (Вы / ИИ).
- Локальные fallback'и: clipboard.writeText на кнопке «Вставить в ячейку», try/catch вокруг localStorage (Safari Private).
- Соответствует Rule #1: ни одно правило линтера/форматтера не ослаблено; `max-lines` для AiChatPanel.ts — targeted-disable с TODO на экстракцию.

## CI

`npm run typecheck && npm run lint && npm run build` — все зелёные.