### PR TITLE
feat: страница тарифов /pricing + переименование Free/Pro/Max на Starter/Developer/Professional

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -34,6 +34,7 @@
 @use '../widgets/profile-section/ProfileSection';
 @use '../widgets/password-section/PasswordSection';
 @use '../widgets/subscription-section/SubscriptionSection';
+@use '../widgets/pricing-table/PricingTable';
 @use '../widgets/editor-settings/EditorSettings';
 @use '../widgets/ai-settings/AiSettings';
 @use '../widgets/feedback-modal/FeedbackModal';

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -50,6 +50,7 @@
 @use '../pages/landing/LandingPage';
 @use '../pages/admin/AdminPage';
 @use '../pages/username-setup/UsernameSetupPage';
+@use '../pages/pricing/PricingPage';
 
 * {
     font-family: var(--font-family-base), serif;
@@ -59,7 +60,8 @@ html {
     scrollbar-gutter: stable;
 }
 
-html, body {
+html,
+body {
     margin: 0;
     padding: 0;
     height: 100%;
@@ -75,11 +77,14 @@ html, body {
     width: 100%;
 }
 
-code, pre, kbd, samp,
+code,
+pre,
+kbd,
+samp,
 .code-cell,
 .code-cell *,
-[class*="code"],
-[class*="Code"],
+[class*='code'],
+[class*='Code'],
 .monospace {
     font-family: var(--font-family-mono), 'Courier New', monospace;
 }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -9,6 +9,7 @@ import { ProfilePage } from '../pages/profile/ProfilePage.js';
 import { AdminPage } from '../pages/admin/AdminPage.js';
 import { SharedFilePage } from '../pages/shared-file/SharedFilePage.js';
 import { UsernameSetupPage } from '../pages/username-setup/UsernameSetupPage.js';
+import { PricingPage } from '../pages/pricing/PricingPage.js';
 import { Router } from '../shared/router/Router.js';
 import { HttpClient } from '../shared/http_client/HttpClient.js';
 import { Heartbeat } from '../shared/heartbeat/Heartbeat.js';
@@ -32,6 +33,7 @@ router.addRoute('/profile', ProfilePage, { guard: 'authOnly' });
 router.addRoute('/admin', AdminPage, { guard: 'authOnly' });
 router.addRoute('/username-setup', UsernameSetupPage, { guard: 'authOnly' });
 router.addRoute('/shared/files/:token', SharedFilePage);
+router.addRoute('/pricing', PricingPage);
 
 /**
  * Опрашивает /auth/me и обновляет snapshot авторизации внутри HttpClient.

--- a/src/pages/pricing/PricingPage.scss
+++ b/src/pages/pricing/PricingPage.scss
@@ -1,0 +1,52 @@
+.pricing-page {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 48px 24px 80px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.pricing-page__hero {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.pricing-page__title {
+    font-size: 36px;
+    font-weight: 700;
+    color: var(--dark-primary);
+    margin: 0;
+}
+
+.pricing-page__subtitle {
+    font-size: 16px;
+    color: var(--accent);
+    max-width: 640px;
+    margin: 0 auto;
+    line-height: 1.5;
+}
+
+.pricing-page__table-wrap {
+    display: flex;
+    flex-direction: column;
+}
+
+.pricing-page__footnote {
+    text-align: center;
+    color: var(--accent);
+    font-size: 13px;
+    font-style: italic;
+}
+
+@media (max-width: 768px) {
+    .pricing-page {
+        padding: 24px 16px 48px;
+    }
+
+    .pricing-page__title {
+        font-size: 28px;
+    }
+}

--- a/src/pages/pricing/PricingPage.template.ts
+++ b/src/pages/pricing/PricingPage.template.ts
@@ -1,0 +1,19 @@
+/**
+ * Возвращает разметку страницы тарифов: hero-блок с заголовком и слот
+ * data-table, в который PricingPage монтирует виджет PricingTable.
+ * @returns HTML-разметку страницы с пустым контейнером таблицы
+ */
+export function PricingPageTemplate(): string {
+    return `
+        <main class="pricing-page">
+            <section class="pricing-page__hero">
+                <h1 class="pricing-page__title">Тарифы</h1>
+                <p class="pricing-page__subtitle">Выберите план, подходящий вашему стилю разработки. В любой момент можно сменить тариф из профиля.</p>
+            </section>
+            <section class="pricing-page__table-wrap" data-table></section>
+            <section class="pricing-page__footnote">
+                <p>Подписка списывается через ЮKassa в тестовом режиме. Реальные деньги не списываются.</p>
+            </section>
+        </main>
+    `;
+}

--- a/src/pages/pricing/PricingPage.ts
+++ b/src/pages/pricing/PricingPage.ts
@@ -1,0 +1,181 @@
+import { GreenHeader } from '../../widgets/green-header/GreenHeader.js';
+import { PricingTable, type PlanId } from '../../widgets/pricing-table/PricingTable.js';
+import { HttpClient } from '../../shared/http_client/HttpClient.js';
+import { Router } from '../../shared/router/Router.js';
+import { logError } from '../../shared/utils/logger.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { isAuthError } from '../../shared/http_client/authStatus.js';
+import { FeedbackModal } from '../../widgets/feedback-modal/FeedbackModal.js';
+import type { ApiEnvelope, UserDTO } from '../../shared/api/types.js';
+import { PricingPageTemplate } from './PricingPage.template.js';
+
+/**
+ * Конфиг шапки в auth-режиме: пользовательский pill + действия dropdown.
+ * Передаётся в GreenHeader без специального DTO, чтобы повторить контракт
+ * существующих страниц (Files/Profile/Disk).
+ */
+interface AuthHeaderConfig {
+    /** Данные user-pill: имя, инициалы, аватар */
+    user: { username: string; initials: string; avatarUrl: string };
+    /** Обработчик клика по «Профиль» */
+    onProfile: () => void;
+    /** Обработчик клика по «Выйти» */
+    onLogout: () => Promise<void>;
+    /** Обработчик клика по «Обратная связь» */
+    onFeedback: () => void;
+    /** Обработчик клика по «Админ-панель» — только если пользователь админ */
+    onAdmin?: () => void;
+}
+
+/**
+ * Публичная страница тарифов /pricing. Доступна и гостям, и авторизованным:
+ * в первом случае рендерит гостевую шапку и виджет PricingTable в режиме
+ * public (CTA ведут на регистрацию), во втором — auth-шапку и виджет в
+ * режиме authenticated (CTA ведут в профиль на оплату). Текущий план
+ * пользователя подсвечивается в таблице.
+ *
+ * Загрузка /auth/me нужна только для того чтобы решить какой режим
+ * рендерить; сама таблица данных с бэка не запрашивает (цены и фичи
+ * декларативные и проверяются бэкендом при оплате).
+ */
+export class PricingPage {
+    #root: HTMLElement;
+    #header: GreenHeader | null = null;
+    #table: PricingTable | null = null;
+    #feedbackModal: FeedbackModal | null = null;
+
+    /**
+     * Запоминает корневой элемент SPA. Рендер откладывается до render().
+     * @param root - корневой контейнер приложения
+     */
+    public constructor(root: HTMLElement) {
+        this.#root = root;
+    }
+
+    /**
+     * Рендерит страницу. Проверяет /auth/me для выбора режима, ставит
+     * соответствующую шапку и монтирует PricingTable. Ошибки сети
+     * (offline / 5xx) тихо переводят страницу в public-режим.
+     */
+    public async render(): Promise<void> {
+        this.#root.innerHTML = '';
+        const user = await this.#probeUser();
+
+        if (user) {
+            this.#renderAuthHeader(user);
+        } else {
+            this.#renderGuestHeader();
+        }
+
+        const tmp = document.createElement('div');
+        tmp.innerHTML = PricingPageTemplate();
+        const page = nn(tmp.firstElementChild) as HTMLElement;
+        this.#root.appendChild(page);
+
+        const tableSlot = nn(page.querySelector<HTMLElement>('[data-table]'));
+        const router = nn(Router.getInstance());
+
+        this.#table = new PricingTable(tableSlot, {
+            mode: user ? 'authenticated' : 'public',
+            currentPlan: user?.plan,
+            onSelectPlan: (plan: PlanId): void => {
+                router.navigate(`/profile?section=subscription&plan=${plan}`);
+            },
+            onPublicCta: (): void => {
+                router.navigate('/sign?mode=register');
+            }
+        });
+        this.#table.mount();
+    }
+
+    /**
+     * Разрушает страницу: размонтирует таблицу и закрывает фидбек-модалку.
+     * Вызывается роутером при переходе на другой маршрут.
+     */
+    public destroy(): void {
+        if (this.#table) this.#table.unmount();
+        if (this.#feedbackModal) this.#feedbackModal.close();
+    }
+
+    /**
+     * Запрашивает /auth/me и возвращает DTO пользователя при успешной сессии.
+     * Любые ошибки трактуются как «гость» — таблица всё равно отрендерится.
+     * @returns DTO пользователя или null если гость / запрос упал
+     */
+    async #probeUser(): Promise<UserDTO | null> {
+        try {
+            const response = await HttpClient.getInstance().get('/auth/me');
+            if (!response.ok) return null;
+            const result = (await response.json()) as Partial<ApiEnvelope<UserDTO>>;
+            return result.data ?? null;
+        } catch (err) {
+            logError('PricingPage.probeUser', err);
+            return null;
+        }
+    }
+
+    /**
+     * Рендерит шапку для авторизованного пользователя: user-pill и dropdown
+     * с навигацией в профиль, выходом, фидбеком и (опционально) админкой.
+     * @param user - DTO авторизованного пользователя
+     */
+    #renderAuthHeader(user: UserDTO): void {
+        const router = nn(Router.getInstance());
+        const initials = user.username.substring(0, 2).toUpperCase();
+
+        const config: AuthHeaderConfig = {
+            user: {
+                username: user.username,
+                initials,
+                avatarUrl: user.avatar_url
+            },
+            onProfile: (): void => {
+                router.navigate('/profile');
+            },
+            onFeedback: (): void => {
+                if (!this.#feedbackModal) this.#feedbackModal = new FeedbackModal();
+                this.#feedbackModal.open();
+            },
+            onLogout: async (): Promise<void> => {
+                try {
+                    const response = await HttpClient.getInstance().post('/auth/logout');
+                    if (response.ok || isAuthError(response.status)) {
+                        router.navigate('/sign');
+                        return;
+                    }
+                    logError('PricingPage logout failed', response.status);
+                } catch (err) {
+                    logError('PricingPage logout error', err);
+                }
+            }
+        };
+
+        if (user.is_admin) {
+            config.onAdmin = (): void => {
+                router.navigate('/admin');
+            };
+        }
+
+        this.#header = new GreenHeader(this.#root, config);
+        this.#header.render();
+    }
+
+    /**
+     * Рендерит гостевую шапку с кнопками «Войти» и «Регистрация».
+     * Клики на кнопки навигируют на /sign с соответствующим режимом.
+     */
+    #renderGuestHeader(): void {
+        const router = nn(Router.getInstance());
+        this.#header = new GreenHeader(this.#root);
+        this.#header.render();
+
+        this.#header.registerBtn?.addEventListener('click', (e: Event) => {
+            e.preventDefault();
+            router.navigate('/sign?mode=register');
+        });
+        this.#header.loginBtn?.addEventListener('click', (e: Event) => {
+            e.preventDefault();
+            router.navigate('/sign?mode=login');
+        });
+    }
+}

--- a/src/shared/api/PaymentApi.ts
+++ b/src/shared/api/PaymentApi.ts
@@ -48,13 +48,15 @@ export class PaymentApi {
     /**
      * Создаёт платёж в ЮKassa за выбранную подписку. Бэк регистрирует
      * платёж в БД и возвращает confirmation_token для рендера виджета.
-     * POST /payments/subscription.
-     * @param plan - имя плана ('pro' или 'max')
+     * POST /payments/subscription. Принимает канонические имена тарифов;
+     * legacy-значения ('pro'/'max') бэкенд нормализует через
+     * domain.NormalizePlan.
+     * @param plan - имя плана ('developer' или 'professional')
      * @param returnURL - URL возврата после оплаты (для виджета)
      * @returns промис с параметрами созданного платежа
      */
     public async createSubscriptionPayment(
-        plan: 'pro' | 'max',
+        plan: 'developer' | 'professional',
         returnURL?: string
     ): Promise<CreatePaymentResponse> {
         const response = await this.#http.post('/payments/subscription', {

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -36,7 +36,7 @@ export interface UserDTO {
     is_verified: boolean;
     /** Имеет ли права администратора (доступ к /admin) */
     is_admin: boolean;
-    /** Тарифный план ('free', 'pro', ...) */
+    /** Тарифный план ('starter', 'developer', 'professional', 'freeze', 'admin'); бэкенд принимает и legacy 'free'/'pro'/'max' */
     plan: string;
     /** Суммарное время активности в секундах (для статистики) */
     total_time_seconds: number;
@@ -422,7 +422,7 @@ export interface AdminActivityStatsResponse {
 export interface PlanDTO {
     /** ID плана в БД */
     id: number;
-    /** Название (служебный идентификатор: 'pro' / 'max') */
+    /** Название (служебный идентификатор: 'developer' / 'professional') */
     name: string;
     /** Цена в копейках (например 99900 = 999 ₽) */
     price_kopeks: number;
@@ -451,7 +451,7 @@ export interface CreatePaymentResponse {
     confirmation_token: string;
     /** Сумма списания в копейках (для UI-отображения) */
     amount_kopeks: number;
-    /** Имя плана ('pro' / 'max') для UI-отображения */
+    /** Имя плана ('developer' / 'professional') для UI-отображения */
     plan: string;
 }
 
@@ -631,7 +631,7 @@ export interface FileUsageResponse {
     limit: number;
     /** true если у пользователя безлимитная квота (admin) */
     unlimited: boolean;
-    /** Тариф пользователя ('free', 'pro', 'max', 'admin', 'freeze') */
+    /** Тариф пользователя ('starter', 'developer', 'professional', 'admin', 'freeze'); legacy 'free'/'pro'/'max' допустимы */
     plan: string;
     /** Количество файлов пользователя */
     files_count: number;

--- a/src/widgets/admin-shared/admin-helpers.ts
+++ b/src/widgets/admin-shared/admin-helpers.ts
@@ -12,20 +12,25 @@ export interface BadgeDescriptor {
  * Маппинг тарифов на бейджи. Используется во всех admin-таблицах.
  */
 export const PLAN_BADGES: Record<string, BadgeDescriptor> = {
-    free: { cls: 'admin-badge--free', label: 'Free' },
+    starter: { cls: 'admin-badge--free', label: 'Starter' },
+    developer: { cls: 'admin-badge--pro', label: 'Developer' },
+    professional: { cls: 'admin-badge--max', label: 'Professional' },
     freeze: { cls: 'admin-badge--freeze', label: 'Freeze' },
-    pro: { cls: 'admin-badge--pro', label: 'Pro' },
-    max: { cls: 'admin-badge--max', label: 'Max' },
-    admin: { cls: 'admin-badge--admin', label: 'Admin' }
+    admin: { cls: 'admin-badge--admin', label: 'Admin' },
+    free: { cls: 'admin-badge--free', label: 'Starter' },
+    pro: { cls: 'admin-badge--pro', label: 'Developer' },
+    max: { cls: 'admin-badge--max', label: 'Professional' }
 };
 
 /**
- * Опции тарифов для select-полей в форме изменения плана.
+ * Опции тарифов для select-полей в форме изменения плана. Используются
+ * канонические значения; legacy ('free'/'pro'/'max') нормализуются бэкендом
+ * через domain.NormalizePlan при записи.
  */
 export const PLAN_OPTIONS = [
-    { value: 'free', label: 'Free' },
-    { value: 'pro', label: 'Pro' },
-    { value: 'max', label: 'Max' },
+    { value: 'starter', label: 'Starter' },
+    { value: 'developer', label: 'Developer' },
+    { value: 'professional', label: 'Professional' },
     { value: 'admin', label: 'Admin' }
 ];
 

--- a/src/widgets/pricing-table/PricingTable.scss
+++ b/src/widgets/pricing-table/PricingTable.scss
@@ -38,9 +38,8 @@
 .pricing-table__col-head {
     background: var(--light-grey);
     color: var(--dark-primary);
-    padding: 36px 12px 16px;
+    padding: 18px 12px 16px;
     vertical-align: top;
-    position: relative;
     white-space: nowrap;
 }
 
@@ -78,23 +77,6 @@
     font-size: 12px;
     color: var(--accent);
     white-space: nowrap;
-}
-
-.pricing-table__col-badge {
-    position: absolute;
-    top: 10px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: var(--teal-green);
-    color: var(--white);
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.5px;
-    padding: 2px 8px;
-    border-radius: 999px;
-    text-transform: uppercase;
-    white-space: nowrap;
-    line-height: 1.3;
 }
 
 .pricing-table__cta-text {

--- a/src/widgets/pricing-table/PricingTable.scss
+++ b/src/widgets/pricing-table/PricingTable.scss
@@ -1,0 +1,141 @@
+.pricing-table {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.pricing-table__columns {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+}
+
+.pricing-table__column {
+    border: 1px solid var(--cell-border);
+    border-radius: 12px;
+    padding: 24px;
+    background: var(--white);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    position: relative;
+}
+
+.pricing-table__column--highlight {
+    border-color: var(--teal-green);
+    box-shadow: 0 8px 24px rgba(2, 115, 104, 0.08);
+}
+
+.pricing-table__column--current {
+    background: var(--light-grey);
+}
+
+.pricing-table__badge {
+    position: absolute;
+    top: -10px;
+    right: 16px;
+    background: var(--teal-green);
+    color: var(--white);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+}
+
+.pricing-table__column-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--teal-green);
+    margin: 0;
+}
+
+.pricing-table__column-price {
+    font-size: 26px;
+    font-weight: 700;
+    color: var(--dark-primary);
+    line-height: 1.1;
+}
+
+.pricing-table__column-period {
+    font-size: 13px;
+    color: var(--accent);
+    margin-top: 2px;
+}
+
+.pricing-table__column-cta {
+    margin-top: auto;
+    background: var(--teal-green);
+    color: var(--white);
+    border: none;
+    border-radius: 8px;
+    padding: 12px 16px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.pricing-table__column-cta:hover {
+    background: var(--teal-green-dark);
+}
+
+.pricing-table__column-cta:disabled {
+    background: var(--grey);
+    cursor: not-allowed;
+}
+
+.pricing-table__rows {
+    border: 1px solid var(--cell-border);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--white);
+}
+
+.pricing-table__row {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr 1fr;
+    align-items: center;
+    padding: 14px 20px;
+    font-size: 14px;
+}
+
+.pricing-table__row + .pricing-table__row {
+    border-top: 1px solid var(--cell-border);
+}
+
+.pricing-table__row-label {
+    font-weight: 600;
+    color: var(--dark-primary);
+}
+
+.pricing-table__row-value {
+    color: var(--accent);
+}
+
+.pricing-table__row-value--highlight {
+    color: var(--dark-primary);
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .pricing-table__columns {
+        grid-template-columns: 1fr;
+    }
+
+    .pricing-table__row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+    }
+
+    .pricing-table__row-label {
+        font-size: 13px;
+        color: var(--accent);
+    }
+
+    .pricing-table__row-value {
+        font-size: 15px;
+        color: var(--dark-primary);
+    }
+}

--- a/src/widgets/pricing-table/PricingTable.scss
+++ b/src/widgets/pricing-table/PricingTable.scss
@@ -1,141 +1,164 @@
 .pricing-table {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
+    width: 100%;
 }
 
-.pricing-table__columns {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-}
-
-.pricing-table__column {
+.pricing-table__table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: var(--white);
     border: 1px solid var(--cell-border);
     border-radius: 12px;
-    padding: 24px;
-    background: var(--white);
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+    overflow: hidden;
+    table-layout: fixed;
+}
+
+.pricing-table__table th,
+.pricing-table__table td {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--cell-border);
+    vertical-align: middle;
+    text-align: center;
+    font-size: 14px;
+}
+
+.pricing-table__table tfoot td {
+    border-bottom: none;
+}
+
+.pricing-table__table th:first-child,
+.pricing-table__table td:first-child {
+    text-align: left;
+    font-weight: 600;
+    color: var(--dark-primary);
+    width: 28%;
+}
+
+.pricing-table__col-head {
+    background: var(--light-grey);
+    color: var(--dark-primary);
+    padding: 18px;
+    vertical-align: top;
+}
+
+.pricing-table__col-head--highlight {
+    background: rgba(2, 115, 104, 0.08);
     position: relative;
 }
 
-.pricing-table__column--highlight {
-    border-color: var(--teal-green);
-    box-shadow: 0 8px 24px rgba(2, 115, 104, 0.08);
+.pricing-table__col-head--current {
+    box-shadow: inset 0 -3px 0 var(--teal-green);
 }
 
-.pricing-table__column--current {
-    background: var(--light-grey);
-}
-
-.pricing-table__badge {
-    position: absolute;
-    top: -10px;
-    right: 16px;
-    background: var(--teal-green);
-    color: var(--white);
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.5px;
-    padding: 4px 10px;
-    border-radius: 999px;
-    text-transform: uppercase;
-}
-
-.pricing-table__column-title {
-    font-size: 20px;
+.pricing-table__col-title {
+    display: block;
+    font-size: 18px;
     font-weight: 700;
     color: var(--teal-green);
-    margin: 0;
+    margin-bottom: 2px;
 }
 
-.pricing-table__column-price {
-    font-size: 26px;
+.pricing-table__col-price {
+    display: block;
+    font-size: 20px;
     font-weight: 700;
     color: var(--dark-primary);
     line-height: 1.1;
 }
 
-.pricing-table__column-period {
-    font-size: 13px;
+.pricing-table__col-period {
+    display: block;
+    font-size: 12px;
     color: var(--accent);
     margin-top: 2px;
 }
 
-.pricing-table__column-cta {
-    margin-top: auto;
+.pricing-table__col-badge {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    background: var(--teal-green);
+    color: var(--white);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding: 3px 8px;
+    border-radius: 999px;
+    text-transform: uppercase;
+}
+
+.pricing-table__group-row td {
+    background: var(--light-grey);
+    text-align: left;
+    font-weight: 700;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--accent);
+}
+
+.pricing-table__cell-value {
+    color: var(--dark-primary);
+}
+
+.pricing-table__cell-yes {
+    color: var(--teal-green);
+    font-weight: 700;
+}
+
+.pricing-table__cell-no {
+    color: var(--grey);
+}
+
+.pricing-table__cta {
+    width: 100%;
     background: var(--teal-green);
     color: var(--white);
     border: none;
     border-radius: 8px;
-    padding: 12px 16px;
+    padding: 12px 14px;
     font-size: 14px;
     font-weight: 600;
     cursor: pointer;
     transition: background 0.15s ease;
 }
 
-.pricing-table__column-cta:hover {
+.pricing-table__cta:hover {
     background: var(--teal-green-dark);
 }
 
-.pricing-table__column-cta:disabled {
+.pricing-table__cta:disabled {
     background: var(--grey);
     cursor: not-allowed;
 }
 
-.pricing-table__rows {
-    border: 1px solid var(--cell-border);
-    border-radius: 12px;
-    overflow: hidden;
-    background: var(--white);
-}
-
-.pricing-table__row {
-    display: grid;
-    grid-template-columns: 1.4fr 1fr 1fr 1fr;
-    align-items: center;
-    padding: 14px 20px;
-    font-size: 14px;
-}
-
-.pricing-table__row + .pricing-table__row {
-    border-top: 1px solid var(--cell-border);
-}
-
-.pricing-table__row-label {
-    font-weight: 600;
-    color: var(--dark-primary);
-}
-
-.pricing-table__row-value {
-    color: var(--accent);
-}
-
-.pricing-table__row-value--highlight {
-    color: var(--dark-primary);
-    font-weight: 600;
-}
-
 @media (max-width: 768px) {
-    .pricing-table__columns {
-        grid-template-columns: 1fr;
+    .pricing-table__table,
+    .pricing-table__table thead,
+    .pricing-table__table tbody,
+    .pricing-table__table tfoot,
+    .pricing-table__table tr,
+    .pricing-table__table th,
+    .pricing-table__table td {
+        display: block;
+        width: 100%;
+        text-align: left;
     }
 
-    .pricing-table__row {
-        grid-template-columns: 1fr;
-        gap: 4px;
+    .pricing-table__table {
+        border: none;
     }
 
-    .pricing-table__row-label {
-        font-size: 13px;
-        color: var(--accent);
+    .pricing-table__col-head {
+        border: 1px solid var(--cell-border);
+        border-radius: 12px;
+        margin-bottom: 12px;
     }
 
-    .pricing-table__row-value {
-        font-size: 15px;
-        color: var(--dark-primary);
+    .pricing-table__table tbody tr {
+        border: 1px solid var(--cell-border);
+        border-radius: 12px;
+        margin-bottom: 12px;
+        padding: 8px 0;
     }
 }

--- a/src/widgets/pricing-table/PricingTable.scss
+++ b/src/widgets/pricing-table/PricingTable.scss
@@ -1,5 +1,6 @@
 .pricing-table {
     width: 100%;
+    overflow-x: auto;
 }
 
 .pricing-table__table {
@@ -10,12 +11,12 @@
     border: 1px solid var(--cell-border);
     border-radius: 12px;
     overflow: hidden;
-    table-layout: fixed;
+    table-layout: auto;
 }
 
 .pricing-table__table th,
 .pricing-table__table td {
-    padding: 14px 18px;
+    padding: 12px 14px;
     border-bottom: 1px solid var(--cell-border);
     vertical-align: middle;
     text-align: center;
@@ -31,60 +32,68 @@
     text-align: left;
     font-weight: 600;
     color: var(--dark-primary);
-    width: 28%;
+    min-width: 220px;
 }
 
 .pricing-table__col-head {
     background: var(--light-grey);
     color: var(--dark-primary);
-    padding: 18px;
+    padding: 28px 12px 16px;
     vertical-align: top;
+    position: relative;
+    white-space: nowrap;
 }
 
 .pricing-table__col-head--highlight {
     background: rgba(2, 115, 104, 0.08);
-    position: relative;
 }
 
 .pricing-table__col-head--current {
     box-shadow: inset 0 -3px 0 var(--teal-green);
 }
 
+.pricing-table__col-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
 .pricing-table__col-title {
-    display: block;
     font-size: 18px;
     font-weight: 700;
     color: var(--teal-green);
-    margin-bottom: 2px;
+    line-height: 1.2;
 }
 
 .pricing-table__col-price {
-    display: block;
     font-size: 20px;
     font-weight: 700;
     color: var(--dark-primary);
     line-height: 1.1;
+    white-space: nowrap;
 }
 
 .pricing-table__col-period {
-    display: block;
     font-size: 12px;
     color: var(--accent);
-    margin-top: 2px;
+    white-space: nowrap;
 }
 
 .pricing-table__col-badge {
     position: absolute;
     top: 6px;
-    right: 8px;
+    left: 50%;
+    transform: translateX(-50%);
     background: var(--teal-green);
     color: var(--white);
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.5px;
-    padding: 3px 8px;
+    padding: 3px 10px;
     border-radius: 999px;
     text-transform: uppercase;
+    white-space: nowrap;
 }
 
 .pricing-table__group-row td {

--- a/src/widgets/pricing-table/PricingTable.scss
+++ b/src/widgets/pricing-table/PricingTable.scss
@@ -38,7 +38,7 @@
 .pricing-table__col-head {
     background: var(--light-grey);
     color: var(--dark-primary);
-    padding: 28px 12px 16px;
+    padding: 36px 12px 16px;
     vertical-align: top;
     position: relative;
     white-space: nowrap;
@@ -82,18 +82,27 @@
 
 .pricing-table__col-badge {
     position: absolute;
-    top: 6px;
+    top: 10px;
     left: 50%;
     transform: translateX(-50%);
     background: var(--teal-green);
     color: var(--white);
-    font-size: 10px;
+    font-size: 9px;
     font-weight: 700;
     letter-spacing: 0.5px;
-    padding: 3px 10px;
+    padding: 2px 8px;
     border-radius: 999px;
     text-transform: uppercase;
     white-space: nowrap;
+    line-height: 1.3;
+}
+
+.pricing-table__cta-text {
+    display: inline-block;
+    padding: 12px 14px;
+    font-size: 13px;
+    color: var(--accent);
+    font-style: italic;
 }
 
 .pricing-table__group-row td {

--- a/src/widgets/pricing-table/PricingTable.template.ts
+++ b/src/widgets/pricing-table/PricingTable.template.ts
@@ -1,0 +1,14 @@
+/**
+ * Возвращает разметку контейнера таблицы тарифов. Колонки и строки фич
+ * рендерятся динамически из PricingTable, поэтому здесь только обёртка
+ * с двумя слотами (заголовки и тело сравнения).
+ * @returns строку HTML с двумя пустыми контейнерами data-columns и data-rows
+ */
+export function PricingTableTemplate(): string {
+    return `
+        <div class="pricing-table">
+            <div class="pricing-table__columns" data-columns></div>
+            <div class="pricing-table__rows" data-rows></div>
+        </div>
+    `;
+}

--- a/src/widgets/pricing-table/PricingTable.template.ts
+++ b/src/widgets/pricing-table/PricingTable.template.ts
@@ -1,14 +1,17 @@
 /**
- * Возвращает разметку контейнера таблицы тарифов. Колонки и строки фич
- * рендерятся динамически из PricingTable, поэтому здесь только обёртка
- * с двумя слотами (заголовки и тело сравнения).
- * @returns строку HTML с двумя пустыми контейнерами data-columns и data-rows
+ * Возвращает обёртку для PricingTable. Внутри одного table-элемента
+ * рендерятся thead (заголовки тарифов с ценой), tbody (строки фич) и
+ * tfoot (кнопки CTA) — всё динамически из PricingTable.
+ * @returns строку HTML с пустой таблицей и thead/tbody/tfoot
  */
 export function PricingTableTemplate(): string {
     return `
         <div class="pricing-table">
-            <div class="pricing-table__columns" data-columns></div>
-            <div class="pricing-table__rows" data-rows></div>
+            <table class="pricing-table__table">
+                <thead data-thead></thead>
+                <tbody data-tbody></tbody>
+                <tfoot data-tfoot></tfoot>
+            </table>
         </div>
     `;
 }

--- a/src/widgets/pricing-table/PricingTable.ts
+++ b/src/widgets/pricing-table/PricingTable.ts
@@ -29,7 +29,7 @@ export interface PricingTableConfig {
 }
 
 /**
- * Описание одной колонки тарифа: визуальные строки и метки.
+ * Описание тарифа в заголовке колонки.
  */
 interface PlanDefinition {
     /** Идентификатор тарифа */
@@ -42,63 +42,125 @@ interface PlanDefinition {
     period: string;
     /** Подсветить как «популярный» */
     highlight: boolean;
-    /** Тексты значений для каждой строки сравнения, ключ — id строки */
-    values: Record<string, string>;
 }
 
 /**
- * Описание одной строки в таблице сравнения.
+ * Тип значения ячейки в строке фич. Скаляр — конкретная подпись,
+ * boolean — флаг доступности (V/X).
+ */
+type CellValue = string | boolean;
+
+/**
+ * Строка с фичей: лейбл + значения для трёх тарифов.
  */
 interface FeatureRow {
-    /** Идентификатор строки (используется как ключ в PlanDefinition.values) */
-    key: string;
-    /** Подпись строки слева */
+    /** Тип строки — обычная строка с данными */
+    kind: 'feature';
+    /** Подпись фичи в левой колонке */
+    label: string;
+    /** Значения по тарифам (порядок: starter, developer, professional) */
+    values: [CellValue, CellValue, CellValue];
+}
+
+/**
+ * Строка-разделитель: подсвечивает категорию (например «LLM-чат»).
+ */
+interface GroupRow {
+    /** Тип строки — заголовок группы */
+    kind: 'group';
+    /** Подпись группы */
     label: string;
 }
 
-const PLAN_DEFINITIONS: PlanDefinition[] = [
+/**
+ * Объединённый тип для одной строки таблицы — либо фича со значениями,
+ * либо заголовок группы.
+ */
+type TableRow = FeatureRow | GroupRow;
+
+const PLAN_DEFINITIONS: [PlanDefinition, PlanDefinition, PlanDefinition] = [
     {
         id: 'starter',
         title: 'Starter',
         priceLabel: 'Бесплатно',
         period: 'навсегда',
-        highlight: false,
-        values: {
-            activeTime: '3 часа активного времени',
-            execQuota: 'Базовая квота запусков кода',
-            llmModels: 'gpt-oss базовый'
-        }
+        highlight: false
     },
     {
         id: 'developer',
         title: 'Developer',
         priceLabel: '999 ₽',
         period: 'в месяц',
-        highlight: true,
-        values: {
-            activeTime: 'Неограниченное время',
-            execQuota: 'Расширенная квота запусков',
-            llmModels: 'gpt-oss базовый + улучшенные модели'
-        }
+        highlight: true
     },
     {
         id: 'professional',
         title: 'Professional',
         priceLabel: '1 999 ₽',
         period: 'в месяц',
-        highlight: false,
-        values: {
-            activeTime: 'Неограниченное время',
-            execQuota: 'Максимальная квота запусков',
-            llmModels: 'Полный доступ ко всем моделям'
-        }
+        highlight: false
     }
 ];
 
-const FEATURE_ROWS: FeatureRow[] = [
-    { key: 'activeTime', label: 'Лимит активного времени' },
-    { key: 'execQuota', label: 'Квота запусков кода' },
-    { key: 'llmModels', label: 'Доступные LLM-модели' }
+const FEATURE_ROWS: TableRow[] = [
+    { kind: 'group', label: 'Ресурсы' },
+    {
+        kind: 'feature',
+        label: 'Хранилище файлов',
+        values: ['128 МБ', '256 МБ', '512 МБ']
+    },
+    {
+        kind: 'feature',
+        label: 'Лимит активного времени',
+        values: ['3 часа', 'Безлимит', 'Безлимит']
+    },
+    {
+        kind: 'feature',
+        label: 'Запусков кода в месяц',
+        values: ['Базовая квота', '100 000', '999 999']
+    },
+    { kind: 'group', label: 'LLM-чат' },
+    {
+        kind: 'feature',
+        label: 'Запросов в день',
+        values: ['20', '200', '1 000']
+    },
+    {
+        kind: 'feature',
+        label: 'Токенов в день',
+        values: ['5 000', '100 000', '1 000 000']
+    },
+    {
+        kind: 'feature',
+        label: 'GPT-4o mini',
+        values: [true, true, true]
+    },
+    {
+        kind: 'feature',
+        label: 'Claude 3.5 Haiku',
+        values: [false, true, true]
+    },
+    {
+        kind: 'feature',
+        label: 'DeepSeek Chat',
+        values: [false, false, true]
+    },
+    {
+        kind: 'feature',
+        label: 'Llama 3.1 70B',
+        values: [false, false, true]
+    },
+    { kind: 'group', label: 'Поддержка' },
+    {
+        kind: 'feature',
+        label: 'Приоритет в очереди исполнения',
+        values: [false, true, true]
+    },
+    {
+        kind: 'feature',
+        label: 'Email-поддержка',
+        values: [false, false, true]
+    }
 ];
 
 const PLAN_ALIASES: Record<string, PlanId> = {
@@ -123,15 +185,16 @@ function normalizePlan(plan: string | undefined): PlanId | undefined {
 }
 
 /**
- * Виджет сравнения тарифов: рендерит три колонки (Starter, Developer,
- * Professional) и таблицу с фичами под ними. Работает в двух режимах:
- * public (для лендинга и страницы /pricing для гостей) и authenticated
- * (для встраивания в SubscriptionSection в профиле). Подсветка «популярного»
- * тарифа и определение текущего плана пользователя — на стороне виджета.
+ * Виджет сравнения тарифов: рендерит одну таблицу с тремя колонками тарифов
+ * и строками фич. Скалярные значения (хранилище, лимиты) показаны как числа,
+ * boolean-фичи (доступ к конкретной LLM-модели) — как галочка V или крест X.
+ * Работает в двух режимах: public (для лендинга и /pricing для гостей) и
+ * authenticated (для встраивания в SubscriptionSection в профиле). Текущий
+ * план пользователя подсвечивается и отключает свою CTA-кнопку.
  *
  * Виджет не загружает данные сам — все цены и фичи статичны (декларативные
- * PLAN_DEFINITIONS), потому что отображаемые надписи это маркетинговые
- * подписи, не runtime-конфиг. Реальные цены проверяются бэкендом при оплате.
+ * PLAN_DEFINITIONS / FEATURE_ROWS), потому что отображаемые надписи это
+ * маркетинговые подписи, не runtime-конфиг. Реальные лимиты enforced бэкендом.
  */
 export class PricingTable extends BaseComponent {
     #config: PricingTableConfig;
@@ -148,12 +211,11 @@ export class PricingTable extends BaseComponent {
     }
 
     /**
-     * Монтирует таблицу в родителя и рисует колонки/строки.
+     * Монтирует таблицу в родителя и рисует thead/tbody/tfoot.
      */
     public override mount(): void {
         super.mount();
-        this.#renderColumns();
-        this.#renderRows();
+        this.#renderTable();
     }
 
     /**
@@ -164,7 +226,7 @@ export class PricingTable extends BaseComponent {
     public refresh(currentPlan: string | undefined): void {
         this.#config = { ...this.#config, currentPlan };
         this._clearListeners();
-        this.#renderColumns();
+        this.#renderTable();
     }
 
     /**
@@ -177,38 +239,93 @@ export class PricingTable extends BaseComponent {
     }
 
     /**
-     * Рисует три карточки тарифов с ценами и CTA-кнопками. Подсвечивает
-     * текущий план (если задан) и «популярный» столбец.
+     * Рендерит все три части таблицы: thead с тарифами и ценой, tbody со
+     * строками фич, tfoot с CTA-кнопками.
      */
-    #renderColumns(): void {
-        const container = nn(this._element.querySelector<HTMLElement>('[data-columns]'));
-        container.innerHTML = '';
-
+    #renderTable(): void {
         const current = normalizePlan(this.#config.currentPlan);
+        this.#renderHead(current);
+        this.#renderBody();
+        this.#renderFoot(current);
+    }
 
-        for (const plan of PLAN_DEFINITIONS) {
-            const card = document.createElement('div');
-            const classes = ['pricing-table__column'];
-            if (plan.highlight) classes.push('pricing-table__column--highlight');
-            if (current === plan.id) classes.push('pricing-table__column--current');
-            card.className = classes.join(' ');
-
-            const ctaLabel = this.#ctaLabelFor(plan.id, current);
-            const ctaDisabled = current === plan.id;
-
-            card.innerHTML = `
-                ${plan.highlight ? '<span class="pricing-table__badge">Популярный</span>' : ''}
-                <h3 class="pricing-table__column-title">${escapeHtml(plan.title)}</h3>
-                <div>
-                    <div class="pricing-table__column-price">${escapeHtml(plan.priceLabel)}</div>
-                    <div class="pricing-table__column-period">${escapeHtml(plan.period)}</div>
-                </div>
-                <button type="button" class="pricing-table__column-cta" data-plan="${escapeHtml(plan.id)}"${ctaDisabled ? ' disabled' : ''}>
-                    ${escapeHtml(ctaLabel)}
-                </button>
+    /**
+     * Рисует строку заголовка таблицы: пустую первую ячейку и три колонки
+     * тарифов с названием, ценой, периодом и (для popular) бейджем.
+     * @param current - канонический id текущего плана пользователя
+     */
+    #renderHead(current: PlanId | undefined): void {
+        const thead = nn(this._element.querySelector<HTMLElement>('[data-thead]'));
+        const cols = PLAN_DEFINITIONS.map((plan) => {
+            const classes = ['pricing-table__col-head'];
+            if (plan.highlight) classes.push('pricing-table__col-head--highlight');
+            if (current === plan.id) classes.push('pricing-table__col-head--current');
+            const badge = plan.highlight
+                ? '<span class="pricing-table__col-badge">Популярный</span>'
+                : '';
+            return `
+                <th scope="col" class="${classes.join(' ')}">
+                    ${badge}
+                    <span class="pricing-table__col-title">${escapeHtml(plan.title)}</span>
+                    <span class="pricing-table__col-price">${escapeHtml(plan.priceLabel)}</span>
+                    <span class="pricing-table__col-period">${escapeHtml(plan.period)}</span>
+                </th>
             `;
-            container.appendChild(card);
+        }).join('');
+        thead.innerHTML = `<tr><th scope="col"></th>${cols}</tr>`;
+    }
+
+    /**
+     * Рисует строки фич в tbody. Группы выводятся как одна объединённая ячейка
+     * на всю ширину. У boolean-значений рендерится V или X.
+     */
+    #renderBody(): void {
+        const tbody = nn(this._element.querySelector<HTMLElement>('[data-tbody]'));
+        const html = FEATURE_ROWS.map((row) => {
+            if (row.kind === 'group') {
+                return `<tr class="pricing-table__group-row"><td colspan="4">${escapeHtml(row.label)}</td></tr>`;
+            }
+            const cells = row.values.map((v) => this.#renderCell(v)).join('');
+            return `<tr><td>${escapeHtml(row.label)}</td>${cells}</tr>`;
+        }).join('');
+        tbody.innerHTML = html;
+    }
+
+    /**
+     * Рендерит одну ячейку строки фич: для строки — текстовое значение,
+     * для true — галочка V, для false — крестик X.
+     * @param value - скалярное или булево значение фичи
+     * @returns HTML-фрагмент <td>...</td>
+     */
+    #renderCell(value: CellValue): string {
+        if (typeof value === 'boolean') {
+            return value
+                ? '<td class="pricing-table__cell-yes" aria-label="Доступно">V</td>'
+                : '<td class="pricing-table__cell-no" aria-label="Недоступно">X</td>';
         }
+        return `<td class="pricing-table__cell-value">${escapeHtml(value)}</td>`;
+    }
+
+    /**
+     * Рисует tfoot с CTA-кнопками для каждой колонки. Делегирует обработчик
+     * клика конфигу: onPublicCta в public-режиме, onSelectPlan в authenticated.
+     * Кнопка под колонкой текущего плана disabled.
+     * @param current - канонический id текущего плана пользователя
+     */
+    #renderFoot(current: PlanId | undefined): void {
+        const tfoot = nn(this._element.querySelector<HTMLElement>('[data-tfoot]'));
+        const cells = PLAN_DEFINITIONS.map((plan) => {
+            const isCurrent = current === plan.id;
+            const label = this.#ctaLabelFor(plan.id, current);
+            return `
+                <td>
+                    <button type="button" class="pricing-table__cta" data-plan="${escapeHtml(plan.id)}"${isCurrent ? ' disabled' : ''}>
+                        ${escapeHtml(label)}
+                    </button>
+                </td>
+            `;
+        }).join('');
+        tfoot.innerHTML = `<tr><td></td>${cells}</tr>`;
 
         const buttons = this._element.querySelectorAll<HTMLButtonElement>('[data-plan]');
         buttons.forEach((btn) => {
@@ -216,31 +333,6 @@ export class PricingTable extends BaseComponent {
                 this.#handleCta(btn.dataset.plan);
             });
         });
-    }
-
-    /**
-     * Рисует таблицу сравнения фич: одна строка на FeatureRow,
-     * первый столбец — лейбл, остальные три — значения для каждого тарифа.
-     */
-    #renderRows(): void {
-        const container = nn(this._element.querySelector<HTMLElement>('[data-rows]'));
-        container.innerHTML = '';
-
-        for (const row of FEATURE_ROWS) {
-            const div = document.createElement('div');
-            div.className = 'pricing-table__row';
-            const values = PLAN_DEFINITIONS.map((p) => {
-                const cls = p.highlight
-                    ? 'pricing-table__row-value pricing-table__row-value--highlight'
-                    : 'pricing-table__row-value';
-                return `<div class="${cls}">${escapeHtml(p.values[row.key] ?? '')}</div>`;
-            }).join('');
-            div.innerHTML = `
-                <div class="pricing-table__row-label">${escapeHtml(row.label)}</div>
-                ${values}
-            `;
-            container.appendChild(div);
-        }
     }
 
     /**

--- a/src/widgets/pricing-table/PricingTable.ts
+++ b/src/widgets/pricing-table/PricingTable.ts
@@ -260,12 +260,8 @@ export class PricingTable extends BaseComponent {
             const classes = ['pricing-table__col-head'];
             if (plan.highlight) classes.push('pricing-table__col-head--highlight');
             if (current === plan.id) classes.push('pricing-table__col-head--current');
-            const badge = plan.highlight
-                ? '<span class="pricing-table__col-badge">Популярный</span>'
-                : '';
             return `
                 <th scope="col" class="${classes.join(' ')}">
-                    ${badge}
                     <div class="pricing-table__col-inner">
                         <span class="pricing-table__col-title">${escapeHtml(plan.title)}</span>
                         <span class="pricing-table__col-price">${escapeHtml(plan.priceLabel)}</span>

--- a/src/widgets/pricing-table/PricingTable.ts
+++ b/src/widgets/pricing-table/PricingTable.ts
@@ -1,0 +1,278 @@
+import { BaseComponent } from '../../shared/components/base-component/BaseComponent.js';
+import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+import { nn } from '../../shared/utils/notNull.js';
+import { PricingTableTemplate } from './PricingTable.template.js';
+
+/**
+ * Канонический идентификатор тарифа на бэкенде после миграции 031.
+ */
+export type PlanId = 'starter' | 'developer' | 'professional';
+
+/**
+ * Режим отображения таблицы. В public CTA ведут на страницу регистрации,
+ * в authenticated — на оплату либо отметку "Текущий план".
+ */
+export type PricingTableMode = 'public' | 'authenticated';
+
+/**
+ * Конфигурация виджета сравнения тарифов.
+ */
+export interface PricingTableConfig {
+    /** Режим: гость (public) или авторизованный (authenticated) */
+    mode: PricingTableMode;
+    /** Текущий план пользователя (может быть legacy 'pro'/'max') — нормализуется внутри */
+    currentPlan?: string;
+    /** Колбэк выбора платного плана из authenticated-режима */
+    onSelectPlan?: (plan: PlanId) => void;
+    /** Колбэк выбора плана из public-режима (обычно навигация на /sign) */
+    onPublicCta?: (plan: PlanId) => void;
+}
+
+/**
+ * Описание одной колонки тарифа: визуальные строки и метки.
+ */
+interface PlanDefinition {
+    /** Идентификатор тарифа */
+    id: PlanId;
+    /** Отображаемый заголовок */
+    title: string;
+    /** Подпись цены (например '999 ₽' или 'Бесплатно') */
+    priceLabel: string;
+    /** Подпись периода под ценой */
+    period: string;
+    /** Подсветить как «популярный» */
+    highlight: boolean;
+    /** Тексты значений для каждой строки сравнения, ключ — id строки */
+    values: Record<string, string>;
+}
+
+/**
+ * Описание одной строки в таблице сравнения.
+ */
+interface FeatureRow {
+    /** Идентификатор строки (используется как ключ в PlanDefinition.values) */
+    key: string;
+    /** Подпись строки слева */
+    label: string;
+}
+
+const PLAN_DEFINITIONS: PlanDefinition[] = [
+    {
+        id: 'starter',
+        title: 'Starter',
+        priceLabel: 'Бесплатно',
+        period: 'навсегда',
+        highlight: false,
+        values: {
+            activeTime: '3 часа активного времени',
+            execQuota: 'Базовая квота запусков кода',
+            llmModels: 'gpt-oss базовый'
+        }
+    },
+    {
+        id: 'developer',
+        title: 'Developer',
+        priceLabel: '999 ₽',
+        period: 'в месяц',
+        highlight: true,
+        values: {
+            activeTime: 'Неограниченное время',
+            execQuota: 'Расширенная квота запусков',
+            llmModels: 'gpt-oss базовый + улучшенные модели'
+        }
+    },
+    {
+        id: 'professional',
+        title: 'Professional',
+        priceLabel: '1 999 ₽',
+        period: 'в месяц',
+        highlight: false,
+        values: {
+            activeTime: 'Неограниченное время',
+            execQuota: 'Максимальная квота запусков',
+            llmModels: 'Полный доступ ко всем моделям'
+        }
+    }
+];
+
+const FEATURE_ROWS: FeatureRow[] = [
+    { key: 'activeTime', label: 'Лимит активного времени' },
+    { key: 'execQuota', label: 'Квота запусков кода' },
+    { key: 'llmModels', label: 'Доступные LLM-модели' }
+];
+
+const PLAN_ALIASES: Record<string, PlanId> = {
+    free: 'starter',
+    pro: 'developer',
+    max: 'professional',
+    starter: 'starter',
+    developer: 'developer',
+    professional: 'professional'
+};
+
+/**
+ * Приводит legacy-имя плана ('free'/'pro'/'max') к каноническому идентификатору.
+ * Возвращает undefined если входной план не распознан как канонический или алиас
+ * (например 'admin'/'freeze' — мы их не отображаем в таблице как «текущий»).
+ * @param plan - произвольная строка имени плана (может быть undefined)
+ * @returns канонический PlanId или undefined
+ */
+function normalizePlan(plan: string | undefined): PlanId | undefined {
+    if (plan === undefined) return undefined;
+    return PLAN_ALIASES[plan];
+}
+
+/**
+ * Виджет сравнения тарифов: рендерит три колонки (Starter, Developer,
+ * Professional) и таблицу с фичами под ними. Работает в двух режимах:
+ * public (для лендинга и страницы /pricing для гостей) и authenticated
+ * (для встраивания в SubscriptionSection в профиле). Подсветка «популярного»
+ * тарифа и определение текущего плана пользователя — на стороне виджета.
+ *
+ * Виджет не загружает данные сам — все цены и фичи статичны (декларативные
+ * PLAN_DEFINITIONS), потому что отображаемые надписи это маркетинговые
+ * подписи, не runtime-конфиг. Реальные цены проверяются бэкендом при оплате.
+ */
+export class PricingTable extends BaseComponent {
+    #config: PricingTableConfig;
+
+    /**
+     * Создаёт виджет. element собирается из шаблона в #render до super.mount.
+     * @param parent - родительский DOM-элемент в который вмонтируется таблица
+     * @param config - режим и колбэки выбора тарифа
+     */
+    public constructor(parent: HTMLElement, config: PricingTableConfig) {
+        super(null, parent);
+        this.#config = config;
+        this.#render();
+    }
+
+    /**
+     * Монтирует таблицу в родителя и рисует колонки/строки.
+     */
+    public override mount(): void {
+        super.mount();
+        this.#renderColumns();
+        this.#renderRows();
+    }
+
+    /**
+     * Перерисовывает таблицу с новым current-планом (например после оплаты).
+     * Сохраняет существующие listeners — все обработчики переустанавливаются.
+     * @param currentPlan - новое значение текущего плана пользователя
+     */
+    public refresh(currentPlan: string | undefined): void {
+        this.#config = { ...this.#config, currentPlan };
+        this._clearListeners();
+        this.#renderColumns();
+    }
+
+    /**
+     * Создаёт корневой элемент из шаблона. _element устанавливается до super.mount().
+     */
+    #render(): void {
+        const tmp = document.createElement('div');
+        tmp.innerHTML = PricingTableTemplate();
+        this._element = nn(tmp.firstElementChild) as HTMLElement;
+    }
+
+    /**
+     * Рисует три карточки тарифов с ценами и CTA-кнопками. Подсвечивает
+     * текущий план (если задан) и «популярный» столбец.
+     */
+    #renderColumns(): void {
+        const container = nn(this._element.querySelector<HTMLElement>('[data-columns]'));
+        container.innerHTML = '';
+
+        const current = normalizePlan(this.#config.currentPlan);
+
+        for (const plan of PLAN_DEFINITIONS) {
+            const card = document.createElement('div');
+            const classes = ['pricing-table__column'];
+            if (plan.highlight) classes.push('pricing-table__column--highlight');
+            if (current === plan.id) classes.push('pricing-table__column--current');
+            card.className = classes.join(' ');
+
+            const ctaLabel = this.#ctaLabelFor(plan.id, current);
+            const ctaDisabled = current === plan.id;
+
+            card.innerHTML = `
+                ${plan.highlight ? '<span class="pricing-table__badge">Популярный</span>' : ''}
+                <h3 class="pricing-table__column-title">${escapeHtml(plan.title)}</h3>
+                <div>
+                    <div class="pricing-table__column-price">${escapeHtml(plan.priceLabel)}</div>
+                    <div class="pricing-table__column-period">${escapeHtml(plan.period)}</div>
+                </div>
+                <button type="button" class="pricing-table__column-cta" data-plan="${escapeHtml(plan.id)}"${ctaDisabled ? ' disabled' : ''}>
+                    ${escapeHtml(ctaLabel)}
+                </button>
+            `;
+            container.appendChild(card);
+        }
+
+        const buttons = this._element.querySelectorAll<HTMLButtonElement>('[data-plan]');
+        buttons.forEach((btn) => {
+            this._addListener(btn, 'click', () => {
+                this.#handleCta(btn.dataset.plan);
+            });
+        });
+    }
+
+    /**
+     * Рисует таблицу сравнения фич: одна строка на FeatureRow,
+     * первый столбец — лейбл, остальные три — значения для каждого тарифа.
+     */
+    #renderRows(): void {
+        const container = nn(this._element.querySelector<HTMLElement>('[data-rows]'));
+        container.innerHTML = '';
+
+        for (const row of FEATURE_ROWS) {
+            const div = document.createElement('div');
+            div.className = 'pricing-table__row';
+            const values = PLAN_DEFINITIONS.map((p) => {
+                const cls = p.highlight
+                    ? 'pricing-table__row-value pricing-table__row-value--highlight'
+                    : 'pricing-table__row-value';
+                return `<div class="${cls}">${escapeHtml(p.values[row.key] ?? '')}</div>`;
+            }).join('');
+            div.innerHTML = `
+                <div class="pricing-table__row-label">${escapeHtml(row.label)}</div>
+                ${values}
+            `;
+            container.appendChild(div);
+        }
+    }
+
+    /**
+     * Возвращает подпись CTA-кнопки для конкретного тарифа исходя из режима
+     * и совпадения с текущим планом пользователя.
+     * @param planId - id тарифа в текущей колонке
+     * @param current - канонический id текущего плана (или undefined)
+     * @returns строку для кнопки
+     */
+    #ctaLabelFor(planId: PlanId, current: PlanId | undefined): string {
+        if (current === planId) return 'Текущий план';
+        if (this.#config.mode === 'public') {
+            return planId === 'starter' ? 'Начать бесплатно' : 'Зарегистрироваться';
+        }
+        if (planId === 'starter') return 'Доступен без оплаты';
+        return 'Оплатить';
+    }
+
+    /**
+     * Обработчик клика по CTA-кнопке: маршрутизирует на нужный колбэк в
+     * зависимости от режима. Принимает значение из data-plan атрибута.
+     * @param plan - id выбранного тарифа из data-plan (или undefined)
+     */
+    #handleCta(plan: string | undefined): void {
+        if (plan !== 'starter' && plan !== 'developer' && plan !== 'professional') {
+            return;
+        }
+        if (this.#config.mode === 'public') {
+            this.#config.onPublicCta?.(plan);
+            return;
+        }
+        if (plan === 'starter') return;
+        this.#config.onSelectPlan?.(plan);
+    }
+}

--- a/src/widgets/pricing-table/PricingTable.ts
+++ b/src/widgets/pricing-table/PricingTable.ts
@@ -266,9 +266,11 @@ export class PricingTable extends BaseComponent {
             return `
                 <th scope="col" class="${classes.join(' ')}">
                     ${badge}
-                    <span class="pricing-table__col-title">${escapeHtml(plan.title)}</span>
-                    <span class="pricing-table__col-price">${escapeHtml(plan.priceLabel)}</span>
-                    <span class="pricing-table__col-period">${escapeHtml(plan.period)}</span>
+                    <div class="pricing-table__col-inner">
+                        <span class="pricing-table__col-title">${escapeHtml(plan.title)}</span>
+                        <span class="pricing-table__col-price">${escapeHtml(plan.priceLabel)}</span>
+                        <span class="pricing-table__col-period">${escapeHtml(plan.period)}</span>
+                    </div>
                 </th>
             `;
         }).join('');

--- a/src/widgets/pricing-table/PricingTable.ts
+++ b/src/widgets/pricing-table/PricingTable.ts
@@ -116,8 +116,8 @@ const FEATURE_ROWS: TableRow[] = [
     },
     {
         kind: 'feature',
-        label: 'Запусков кода в месяц',
-        values: ['Базовая квота', '100 000', '999 999']
+        label: 'Квота запусков кода в месяц',
+        values: ['50 000', '100 000', '999 999']
     },
     { kind: 'group', label: 'LLM-чат' },
     {
@@ -316,17 +316,9 @@ export class PricingTable extends BaseComponent {
      */
     #renderFoot(current: PlanId | undefined): void {
         const tfoot = nn(this._element.querySelector<HTMLElement>('[data-tfoot]'));
-        const cells = PLAN_DEFINITIONS.map((plan) => {
-            const isCurrent = current === plan.id;
-            const label = this.#ctaLabelFor(plan.id, current);
-            return `
-                <td>
-                    <button type="button" class="pricing-table__cta" data-plan="${escapeHtml(plan.id)}"${isCurrent ? ' disabled' : ''}>
-                        ${escapeHtml(label)}
-                    </button>
-                </td>
-            `;
-        }).join('');
+        const cells = PLAN_DEFINITIONS.map(
+            (plan) => `<td>${this.#renderCtaCell(plan.id, current)}</td>`
+        ).join('');
         tfoot.innerHTML = `<tr><td></td>${cells}</tr>`;
 
         const buttons = this._element.querySelectorAll<HTMLButtonElement>('[data-plan]');
@@ -335,6 +327,28 @@ export class PricingTable extends BaseComponent {
                 this.#handleCta(btn.dataset.plan);
             });
         });
+    }
+
+    /**
+     * Решает чем заполнить футер-ячейку конкретной колонки: кнопкой
+     * «Оплатить» / «Зарегистрироваться» / «Начать бесплатно», disabled-кнопкой
+     * «Текущий план» или просто текстовой подписью «Доступен без оплаты»
+     * (для Starter в authenticated-режиме, чтобы не выглядело как активная CTA).
+     * @param planId - id тарифа в текущей колонке
+     * @param current - канонический id текущего плана пользователя (или undefined)
+     * @returns HTML-фрагмент содержимого <td>
+     */
+    #renderCtaCell(planId: PlanId, current: PlanId | undefined): string {
+        const isCurrent = current === planId;
+        if (this.#config.mode === 'authenticated' && planId === 'starter' && !isCurrent) {
+            return '<span class="pricing-table__cta-text">Доступен без оплаты</span>';
+        }
+        const label = this.#ctaLabelFor(planId, current);
+        return `
+            <button type="button" class="pricing-table__cta" data-plan="${escapeHtml(planId)}"${isCurrent ? ' disabled' : ''}>
+                ${escapeHtml(label)}
+            </button>
+        `;
     }
 
     /**

--- a/src/widgets/resource-banner/ResourceBanner.ts
+++ b/src/widgets/resource-banner/ResourceBanner.ts
@@ -56,17 +56,21 @@ export class ResourceBanner extends BaseComponent {
 
     /**
      * Заполняет все значения баннера данными UserStats. Маппит machine-имя плана
-     * (free/freeze/pro/max/admin) в человекочитаемое; форматирует время как
-     * "Xч Yмин / Zч"; для безлимита — "Безлимит".
+     * (starter/developer/professional/freeze/admin) в человекочитаемое; для
+     * совместимости со старыми ответами /stats принимает legacy free/pro/max.
+     * Форматирует время как "Xч Yмин / Zч"; для безлимита — "Безлимит".
      * @param stats - статистика пользователя от StatsApi
      */
     #populate(stats: UserStats): void {
         const planNames: Record<string, string> = {
-            free: 'Free',
+            starter: 'Starter',
+            developer: 'Developer',
+            professional: 'Professional',
             freeze: 'Freeze',
-            pro: 'Pro',
-            max: 'Max',
-            admin: 'Admin'
+            admin: 'Admin',
+            free: 'Starter',
+            pro: 'Developer',
+            max: 'Professional'
         };
 
         const badge = nn(this._element.querySelector('[data-field="plan"]'));

--- a/src/widgets/stats-section/StatsSection.ts
+++ b/src/widgets/stats-section/StatsSection.ts
@@ -95,11 +95,14 @@ export class StatsSection extends BaseComponent {
         const fill = nn(this._element.querySelector<HTMLElement>('.stats-section__progress-fill'));
 
         const planNames: Record<string, string> = {
-            free: 'Free',
+            starter: 'Starter',
+            developer: 'Developer',
+            professional: 'Professional',
             freeze: 'Freeze',
-            pro: 'Pro',
-            max: 'Max',
-            admin: 'Admin'
+            admin: 'Admin',
+            free: 'Starter',
+            pro: 'Developer',
+            max: 'Professional'
         };
         badge.textContent = planNames[stats.quota.plan] || stats.quota.plan;
         badge.classList.add(`stats-section__plan-badge--${stats.quota.plan}`);

--- a/src/widgets/subscription-section/SubscriptionSection.scss
+++ b/src/widgets/subscription-section/SubscriptionSection.scss
@@ -33,79 +33,7 @@
 }
 
 .subscription-section__plans {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
     margin-bottom: 16px;
-}
-
-@media (max-width: 768px) {
-    .subscription-section__plans {
-        grid-template-columns: 1fr;
-    }
-}
-
-.subscription-section__plan-card {
-    border: 1px solid var(--cell-border);
-    border-radius: 12px;
-    padding: 20px;
-    background: var(--white);
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.subscription-section__plan-card--current {
-    border-color: var(--teal-green);
-    background: var(--light-grey);
-}
-
-.subscription-section__plan-card-title {
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--teal-green);
-    margin: 0;
-}
-
-.subscription-section__plan-card-price {
-    font-size: 24px;
-    font-weight: 700;
-    color: var(--dark-primary);
-}
-
-.subscription-section__plan-card-period {
-    font-size: 13px;
-    color: var(--accent);
-}
-
-.subscription-section__plan-card-features {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    font-size: 14px;
-    color: var(--accent);
-    line-height: 1.6;
-}
-
-.subscription-section__plan-card-button {
-    background: var(--teal-green);
-    color: var(--white);
-    border: none;
-    border-radius: 8px;
-    padding: 10px 16px;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.15s ease;
-}
-
-.subscription-section__plan-card-button:hover {
-    background: var(--teal-green-dark);
-}
-
-.subscription-section__plan-card-button:disabled {
-    background: var(--grey);
-    cursor: not-allowed;
 }
 
 .subscription-section__widget-wrap {

--- a/src/widgets/subscription-section/SubscriptionSection.template.ts
+++ b/src/widgets/subscription-section/SubscriptionSection.template.ts
@@ -1,8 +1,8 @@
 /**
  * Рендерит секцию управления подпиской в профиле. Содержит карточку текущего
- * плана, две карточки доступных тарифов (Pro/Max) с кнопками оплаты и пустой
- * контейнер для встраивания виджета ЮKassa в режиме embedded.
- * Сами карточки тарифов наполняются динамически из API в SubscriptionSection.
+ * плана, контейнер data-plans под виджет PricingTable (рендерится из
+ * SubscriptionSection) и пустой контейнер для встраивания виджета ЮKassa
+ * в режиме embedded.
  * @returns HTML-разметка для innerHTML
  */
 export function SubscriptionSectionTemplate(): string {

--- a/src/widgets/subscription-section/SubscriptionSection.ts
+++ b/src/widgets/subscription-section/SubscriptionSection.ts
@@ -2,9 +2,8 @@ import { BaseComponent } from '../../shared/components/base-component/BaseCompon
 import { PaymentApi } from '../../shared/api/PaymentApi.js';
 import { logError } from '../../shared/utils/logger.js';
 import { nn } from '../../shared/utils/notNull.js';
-import { escapeHtml } from '../../shared/utils/escapeHtml.js';
+import { PricingTable, type PlanId } from '../pricing-table/PricingTable.js';
 import { SubscriptionSectionTemplate } from './SubscriptionSection.template.js';
-import type { PlanDTO } from '../../shared/api/types.js';
 
 /**
  * Внешний URL JS-библиотеки виджета ЮKassa Checkout. Загружается лениво
@@ -22,6 +21,17 @@ function formatRubles(kopeks: number): string {
     const fracPart = kopeks % 100;
     return `${String(intPart)}.${fracPart.toString().padStart(2, '0')}`;
 }
+
+const PLAN_DISPLAY_NAMES: Record<string, string> = {
+    starter: 'Starter',
+    developer: 'Developer',
+    professional: 'Professional',
+    free: 'Starter',
+    pro: 'Developer',
+    max: 'Professional',
+    freeze: 'Заморожен (исчерпан лимит)',
+    admin: 'Admin'
+};
 
 /**
  * Минимальный контракт глобального конструктора виджета ЮKassa.
@@ -74,29 +84,6 @@ interface SubscriptionSectionConfig {
 }
 
 /**
- * Описание тарифа для шаблона карточки.
- */
-interface PlanCardData {
-    /** Идентификатор плана для API ('pro' / 'max') */
-    name: string;
-    /** Заголовок карточки */
-    title: string;
-    /** Цена в копейках */
-    priceKopeks: number;
-    /** Список фич для отображения */
-    features: string[];
-}
-
-/**
- * Заранее заданные тексты для карточек тарифов. Реальные цены/квоты приходят
- * из API (/subscription/plans), но описание UI задаётся локально.
- */
-const PLAN_FEATURES: Record<string, string[]> = {
-    pro: ['Безлимитное время работы', 'Расширенная квота запусков кода', 'Приоритет в очереди'],
-    max: ['Всё из Pro', 'Максимальная квота запусков', 'Поддержка по email']
-};
-
-/**
  * Интервал поллинга статуса платежа в миллисекундах.
  */
 const POLL_INTERVAL_MS = 2000;
@@ -114,7 +101,7 @@ const POLL_INTERVAL_MS = 2000;
 export class SubscriptionSection extends BaseComponent {
     #config: SubscriptionSectionConfig;
     #api: PaymentApi;
-    #plans: PlanDTO[] = [];
+    #table: PricingTable | null = null;
     #pollTimer: number | null = null;
     #widget: YooKassaWidget | null = null;
     #scriptLoading: Promise<void> | null = null;
@@ -149,6 +136,10 @@ export class SubscriptionSection extends BaseComponent {
     public override unmount(): void {
         this.#stopPolling();
         this.#destroyWidget();
+        if (this.#table) {
+            this.#table.unmount();
+            this.#table = null;
+        }
         super.unmount();
     }
 
@@ -180,17 +171,13 @@ export class SubscriptionSection extends BaseComponent {
      */
     async #initialize(): Promise<void> {
         try {
-            const [plansResp, subResp] = await Promise.all([
-                this.#api.listPlans(),
-                this.#api.getMySubscription()
-            ]);
-            this.#plans = plansResp.plans;
+            const subResp = await this.#api.getMySubscription();
             this.#renderCurrent(subResp.plan, subResp.expires_at);
             this.#renderPlans(subResp.plan);
         } catch (err) {
             logError('SubscriptionSection.initialize', err);
-            this.#renderCurrent('free');
-            this.#renderPlans('free');
+            this.#renderCurrent('starter');
+            this.#renderPlans('starter');
         }
     }
 
@@ -205,20 +192,15 @@ export class SubscriptionSection extends BaseComponent {
         if (!card) return;
         const nameEl = card.querySelector('.subscription-section__plan-name');
         const descEl = card.querySelector('.subscription-section__plan-desc');
-        const labelMap: Record<string, string> = {
-            free: 'Бесплатный план',
-            freeze: 'Заморожен (исчерпан лимит)',
-            pro: 'Pro',
-            max: 'Max',
-            admin: 'Admin'
-        };
-        if (nameEl) nameEl.textContent = labelMap[plan] ?? plan;
+        if (nameEl) nameEl.textContent = PLAN_DISPLAY_NAMES[plan] ?? plan;
 
         if (descEl) {
-            if ((plan === 'pro' || plan === 'max') && expiresAt !== undefined && expiresAt > 0) {
+            const isPaid =
+                plan === 'developer' || plan === 'professional' || plan === 'pro' || plan === 'max';
+            if (isPaid && expiresAt !== undefined && expiresAt > 0) {
                 const date = new Date(expiresAt * 1000);
                 descEl.textContent = `Активна до ${date.toLocaleDateString('ru-RU')}`;
-            } else if (plan === 'free') {
+            } else if (plan === 'starter' || plan === 'free') {
                 descEl.textContent = 'Базовый доступ. Лимит: 3 часа активности.';
             } else if (plan === 'freeze') {
                 descEl.textContent = 'Лимит времени исчерпан. Оплатите подписку чтобы продолжить.';
@@ -229,62 +211,35 @@ export class SubscriptionSection extends BaseComponent {
     }
 
     /**
-     * Рендерит карточки доступных тарифов (Pro и Max) с кнопками "Оплатить".
-     * Для текущего плана кнопка disabled и подсвечена.
+     * Монтирует виджет PricingTable в data-plans (если ещё не смонтирован),
+     * либо обновляет в нём currentPlan. CTA-клик платного плана запускает
+     * #startPayment в режиме authenticated.
      * @param currentPlan - текущий план пользователя
      */
     #renderPlans(currentPlan: string): void {
-        const container = this._element.querySelector('[data-plans]');
-        if (!container) return;
-        container.innerHTML = '';
-
-        const cards: PlanCardData[] = this.#plans
-            .filter((p) => p.name === 'pro' || p.name === 'max')
-            .map((p) => ({
-                name: p.name,
-                title: p.name === 'pro' ? 'Pro' : 'Max',
-                priceKopeks: p.price_kopeks,
-                features: PLAN_FEATURES[p.name] ?? []
-            }));
-
-        for (const card of cards) {
-            const isCurrent = card.name === currentPlan;
-            const div = document.createElement('div');
-            div.className = `subscription-section__plan-card${isCurrent ? ' subscription-section__plan-card--current' : ''}`;
-            div.innerHTML = `
-                <h4 class="subscription-section__plan-card-title">${escapeHtml(card.title)}</h4>
-                <div>
-                    <div class="subscription-section__plan-card-price">${formatRubles(card.priceKopeks)} ₽</div>
-                    <div class="subscription-section__plan-card-period">в месяц</div>
-                </div>
-                <ul class="subscription-section__plan-card-features">
-                    ${card.features.map((f) => `<li>• ${escapeHtml(f)}</li>`).join('')}
-                </ul>
-                <button type="button" class="subscription-section__plan-card-button"
-                        data-buy="${escapeHtml(card.name)}" ${isCurrent ? 'disabled' : ''}>
-                    ${isCurrent ? 'Текущий план' : 'Оплатить'}
-                </button>
-            `;
-            container.appendChild(div);
+        if (this.#table) {
+            this.#table.refresh(currentPlan);
+            return;
         }
-
-        const buttons = this._element.querySelectorAll('[data-buy]');
-        buttons.forEach((btn) => {
-            this._addListener(btn, 'click', () => {
-                const plan = (btn as HTMLElement).dataset.buy;
-                if (plan === 'pro' || plan === 'max') {
-                    void this.#startPayment(plan);
-                }
-            });
+        const container = nn(this._element.querySelector<HTMLElement>('[data-plans]'));
+        container.innerHTML = '';
+        this.#table = new PricingTable(container, {
+            mode: 'authenticated',
+            currentPlan,
+            onSelectPlan: (plan: PlanId): void => {
+                if (plan === 'starter') return;
+                void this.#startPayment(plan);
+            }
         });
+        this.#table.mount();
     }
 
     /**
      * Стартует процесс оплаты: создаёт платёж на бэке, загружает (если ещё
      * нет) скрипт ЮKassa, монтирует виджет и запускает поллинг статуса.
-     * @param plan - выбранный план ('pro' | 'max')
+     * @param plan - выбранный план ('developer' | 'professional')
      */
-    async #startPayment(plan: 'pro' | 'max'): Promise<void> {
+    async #startPayment(plan: 'developer' | 'professional'): Promise<void> {
         this.#showStatus('info', 'Создаём платёж...');
         try {
             const created = await this.#api.createSubscriptionPayment(plan);


### PR DESCRIPTION
## Зачем

Добавляем полноценную страницу прайсинга (типичный SaaS-паттерн) и переходим на маркетинговые названия тарифов, ориентированные на разработчиков. Бэкенд-часть в PR `go-park-mail-ru/2026_1_KISS#114`.

## Что меняем

- **Виджет `PricingTable`** (`src/widgets/pricing-table/`) — переиспользуемая таблица сравнения с одним table-элементом: thead с тремя колонками тарифов и ценой, tbody со строками фич (хранилище, лимит активного времени, квота запусков, лимиты LLM-чата, доступ к конкретным моделям через `V` / `X`, опции поддержки), tfoot с CTA-кнопкой на колонку. Два режима: `public` (CTA ведёт на регистрацию) и `authenticated` (CTA триггерит оплату через колбэк). Значения декларативные и взяты из реальных бэкенд-настроек: `internal/pkg/quota` (128 / 256 / 512 MB), `CHAT_*_REQUESTS` / `CHAT_*_TOKENS` из docker-compose, список моделей из `CHAT_*_MODELS`.
- **Страница `/pricing`** (`src/pages/pricing/`) — самостоятельный маршрут без guard'а. Через `/auth/me` решает, какую шапку рисовать: гостевую (с кнопками `Войти` / `Регистрация`) или авторизованную (user-pill + dropdown). Под шапкой — `PricingTable` в соответствующем режиме.
- **Профиль**: `SubscriptionSection` теперь встраивает `PricingTable` вместо двух inline-карточек. Логика оплаты через ЮKassa, поллинг статуса и обновление текущего плана остаются в `SubscriptionSection`; виджет только триггерит `onSelectPlan`. Удалены устаревшие inline-стили `__plan-card*`. `PaymentApi.createSubscriptionPayment` объявляет канонические имена `developer` / `professional` — бэкенд принимает и легаси через `domain.NormalizePlan`.
- **Лейблы в админке, баннере и stats**: `PLAN_BADGES` / `PLAN_OPTIONS` в `admin-helpers.ts`, маппинги в `ResourceBanner` и `StatsSection` обновлены на `Starter` / `Developer` / `Professional`. Легаси-ключи `free` / `pro` / `max` сохранены в display-картах, чтобы немигрированные записи отображались с новыми лейблами вместо raw-идентификатора.
- **Полировка вёрстки таблицы**: ушли с `table-layout: fixed` на `auto` + `min-width: 220px` на первой колонке, цена и заголовок обёрнуты во flex-колонку `pricing-table__col-inner`, `white-space: nowrap` на критичных подписях. CTA для Starter в auth-режиме — текстовая подпись курсивом вместо disabled-кнопки. Бейдж `Популярный` убран по запросу — Developer всё ещё подсвечен тёплым фоном через класс `col-head--highlight`.

## План проверки

- [x] `npm run typecheck` — чисто
- [x] `npm run lint` (`--max-warnings 0`) — чисто
- [x] `npm run format:check` — чисто
- [x] `act pull_request --container-architecture linux/amd64 -j lint` локально — оба job (CI и Deploy) успешны
- [x] Прогон в браузере на `PORT=3001 npm run dev` (3000 занят Grafana): `/pricing` доступна гостю, показывает три тарифа; `/profile?section=subscription` показывает встроенную таблицу с подсветкой текущего плана и работающей кнопкой `Оплатить`
- [x] Лейблы в `/admin` (бейджи в таблице пользователей), в `ResourceBanner` и `StatsSection` показывают `Starter` / `Developer` / `Professional`

## Связанный PR на бэке

go-park-mail-ru/2026_1_KISS#114 — миграция 031, переименование констант, alias-слой совместимости.