### PR TITLE
fix(config): preserve /jeager/ prefix when proxying to Jaeger UI

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -104,14 +104,11 @@ server {
     }
 
     location ^~ /jeager/ {
-        proxy_pass http://212.233.96.54:16686/;
+        proxy_pass http://212.233.96.54:16686;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
## Summary
- Removed the trailing slash from `proxy_pass` in the `/jeager/` location so nginx forwards the full request URI to Jaeger.
- Dropped the WebSocket `Upgrade`/`Connection` headers that were copied from the Grafana block but are not used by Jaeger UI.

## Why it was broken
The Jaeger container is started with `QUERY_BASE_PATH=/jeager` (see `go_2026_1_KISS/docker-compose.yml`), so it expects every request — HTML, JS bundle, `/api/services`, etc. — to come under that prefix.

With `proxy_pass http://...:16686/;` (trailing slash), nginx strips the `location` prefix and forwards `GET /` instead of `GET /jeager/`. Jaeger then issues a redirect back to `/jeager/`, and the static asset paths under `/jeager/static/...` get rewritten to `/static/...` on the upstream — which 404s. The net effect on `https://colkiss.ru/jeager/` was a blank page / broken assets.

Removing the trailing slash makes nginx forward the URI verbatim, which is exactly what `QUERY_BASE_PATH` is designed for. Same pattern as the existing `/grafana/` block.

## Test plan
- [ ] Deploy to `develop`/`main` server, wait for nginx reload.
- [ ] `curl -I https://colkiss.ru/jeager/` returns `200 OK` and HTML.
- [ ] Open `https://colkiss.ru/jeager/` in a browser: UI loads, services list populates, a trace can be opened end-to-end.
- [ ] No console errors about missing `/static/...` assets.

## Follow-ups (out of scope)
- Fix the `jeager` typo across nginx + `docker-compose.yml` (`QUERY_BASE_PATH`) in a coordinated PR.
- Bind Jaeger port `16686` to `127.0.0.1` only and add `auth_basic` in nginx — currently the UI is publicly reachable on `212.233.96.54:16686` without auth.
- Add `restart: unless-stopped` to the `jaeger` service in `docker-compose.yml`.